### PR TITLE
Contracts: fix type error in processRedeeming. Fixes #32.

### DIFF
--- a/contracts/OpenSTUtility.sol
+++ b/contracts/OpenSTUtility.sol
@@ -483,7 +483,7 @@ contract OpenSTUtility is Hasher, OpsManaged {
     }
 
     function processRedeeming(
-    	bytes23 _redemptionIntentHash)
+    	bytes32 _redemptionIntentHash)
     	external
     	returns (
     	address tokenAddress)


### PR DESCRIPTION
Correct `bytes23` to `bytes32`.