### PR TITLE
minimum redemption amount required to conversionRate UT Wei

### DIFF
--- a/contracts/OpenSTValue.sol
+++ b/contracts/OpenSTValue.sol
@@ -274,6 +274,8 @@ contract OpenSTValue is OpsManaged, Hasher {
     	expirationHeight = block.number + BLOCKS_TO_WAIT_SHORT;
 
     	UtilityToken storage utilityToken = utilityTokens[_uuid];
+    	// minimal precision to unstake 1 STWei
+    	require(_amountUT >= utilityToken.conversionRate);
     	amountST = _amountUT.div(utilityToken.conversionRate);
 
     	require(valueToken.balanceOf(address(utilityToken.simpleStake)) >= amountST);


### PR DESCRIPTION
for minimal precision of unstaking 1 ST Wei, we require minimum redemption amount to be required to be conversionRate UT Wei

fixes #39 