### PR TITLE
truffle: enable 200 optimizer runs on tests

### DIFF
--- a/truffle.js
+++ b/truffle.js
@@ -5,5 +5,14 @@ module.exports = {
       port: 8545,
       network_id: "*" // Match any network id
     }
+  },
+  solc: {
+    optimizer: {
+      enabled: true,
+      // set to same number of runs as openst-platform
+      // so that integration tests on openst-protocol
+      // give accurate gas measurements
+      runs: 200
+    }
   }
 };


### PR DESCRIPTION
fixes #53 

this now produces the exact same gas consumption on in the integration test of openst-protocol as it does on the deployment tests of openst-platform on ropsten:

```
OpenSTValue.new                            2889358
OpenSTUtility.new                            4503101
```