### PR TITLE
On failed and reverted redemption, allow reuse of nonce

### DIFF
--- a/contracts/OpenSTUtility.sol
+++ b/contracts/OpenSTUtility.sol
@@ -442,7 +442,11 @@ contract OpenSTUtility is Hasher, OpsManaged {
     {
     	require(_uuid != "");
     	require(_amountBT > 0);
-    	require(_nonce > nonces[msg.sender]);
+    	// on redemption allow the nonce to be re-used to cover for an unsuccessful
+    	// previous redemption previously; as the nonce is strictly increasing plus
+    	// one on the value chain; there is no gain on redeeming with the same nonce,
+    	// only self-inflicted cost.
+    	require(_nonce >= nonces[msg.sender]);
     	nonces[msg.sender] = _nonce;
 
     	// to redeem ST' one needs to send value to payable
@@ -489,7 +493,11 @@ contract OpenSTUtility is Hasher, OpsManaged {
     	bytes32 redemptionIntentHash)
     {
     	require(msg.value > 0);
-    	require(_nonce > nonces[msg.sender]);
+    	// on redemption allow the nonce to be re-used to cover for an unsuccessful
+    	// previous redemption previously; as the nonce is strictly increasing plus
+    	// one on the value chain; there is no gain on redeeming with the same nonce,
+    	// only self-inflicted cost.
+    	require(_nonce >= nonces[msg.sender]);
     	nonces[msg.sender] = _nonce;
 
     	amountSTP = msg.value;
@@ -566,7 +574,7 @@ contract OpenSTUtility is Hasher, OpsManaged {
 
 		uuid = redemption.uuid;
 		amountUT = redemption.amountUT;
-		redeemer = redemption.redeemer;		
+		redeemer = redemption.redeemer;
 
 		if (redemption.uuid == uuidSTPrime) {
 	        // transfer throws if insufficient funds


### PR DESCRIPTION
Fixes #56 

Original proposal was to revert back the nonce on the utility chain (as monotonic nonce is kept on value chain); but the more elegant solution is to loosen the requirement on `redeem` and `redeemSTP` on `OpenSTUtility`;

as such a redeemer could redeem multiple times with the same nonce, but only one could be used to unstake, and as a result the redeemer only incurs a cost of handing over utility tokens on redeeming multiple times;

however if a redemption attempt fails, and is reverted, the redeemer can reuse the same nonce to retry the redemption.

addressed unit tests for this change in requirements.