### PR TITLE
Add JSON/MD documentation of protocol smart contracts

### DIFF
--- a/docs/json/BrandedToken.json
+++ b/docs/json/BrandedToken.json
@@ -1,0 +1,111 @@
+
+{
+   "methods" : {
+      "allowance(address,address)" : {
+         "details" : "Takes _owner, _spender; returns remaining allowance of _spender from _owner",
+         "params" : {
+            "_owner" : "owner",
+            "_spender" : "spender"
+         },
+         "return" : "remaining"
+      },
+      "approve(address,uint256)" : {
+         "details" : "Takes _spender, _value; approves _spender to transfer _value from msg.sender; emits Approval event",
+         "params" : {
+            "_spender" : "spender",
+            "_value" : "value"
+         },
+         "return" : "success"
+      },
+      "balanceOf(address)" : {
+         "details" : "Takes _owner; returns balance of _owner",
+         "params" : {
+            "_owner" : "owner"
+         },
+         "return" : "balance"
+      },
+      "burn(address,uint256)" : {
+         "details" : "Takes _burner, _amount; calls burnEIP20 and returns the result of calling burnInternal; only callable by protocol",
+         "params" : {
+            "_amount" : "amount",
+            "_burner" : "burner"
+         },
+         "return" : "bool"
+      },
+      "claim(address)" : {
+         "details" : "Takes _beneficiary; calls claimInternal and returns the result of calling claimEIP20",
+         "params" : {
+            "_beneficiary" : "beneficiary"
+         },
+         "return" : "bool"
+      },
+      "completeProtocolTransfer()" : {
+         "details" : "Only after the waiting period, can proposed protocol complete the transfer; emits ProtocolTransferCompleted event; only callable by proposed protocol",
+         "return" : "success bool"
+      },
+      "decimals()" : {
+         "details" : "Returns decimals",
+         "return" : "uint8"
+      },
+      "initiateProtocolTransfer(address)" : {
+         "details" : "Takes _proposedProtocol; initiates protocol transfer; emits ProtocolTransferInitiated event; only callable by protocol",
+         "params" : {
+            "_proposedProtocol" : "proposedProtocol"
+         },
+         "return" : "success bool"
+      },
+      "mint(address,uint256)" : {
+         "details" : "Takes _beneficiary, _amount; calls mintEIP20 and returns the result of calling mintInternal; only callable by protocol",
+         "params" : {
+            "_amount" : "amount",
+            "_beneficiary" : "beneficiary"
+         },
+         "return" : "bool"
+      },
+      "name()" : {
+         "details" : "Returns name",
+         "return" : "string"
+      },
+      "revokeProtocolTransfer()" : {
+         "details" : "protocol can revoke initiated protocol transfer; emits ProtocolTransferRevoked event; only callable by protocol",
+         "return" : "success bool"
+      },
+      "symbol()" : {
+         "details" : "Returns symbol",
+         "return" : "string"
+      },
+      "totalSupply()" : {
+         "details" : "Get totalTokenSupply as view so that child cannot edit",
+         "return" : "uint256"
+      },
+      "transfer(address,uint256)" : {
+         "details" : "Takes _to, _value; transfers _value from balance of msg.sender to _to; emits Transfer event",
+         "params" : {
+            "_to" : "to",
+            "_value" : "value"
+         },
+         "return" : "success"
+      },
+      "transferFrom(address,address,uint256)" : {
+         "details" : "Takes _from, _to, _value; transfers _value from balance of _from to _to; emits Transfer event",
+         "params" : {
+            "_from" : "from",
+            "_to" : "to",
+            "_value" : "value"
+         },
+         "return" : "success"
+      },
+      "unclaimed(address)" : {
+         "details" : "Takes _beneficiary; returns unclaimed amount for _beneficiary",
+         "params" : {
+            "_beneficiary" : "beneficiary"
+         },
+         "return" : "uint256"
+      },
+      "uuid()" : {
+         "details" : "Returns uuid",
+         "return" : "bytes32"
+      }
+   },
+   "title" : "BrandedToken - An EIP20 token minted by staking Simple Token on Ethereum mainnet. Branded tokens are designed to be used within a (decentralised) application and support: smart contract controlled password reset for users who don't yet (hard-spoon FTW) manage their own private keys (+v0.9.2); soft-exit for a user to redeem their equivalent part of the Simple Token stake on Ethereum mainnet; hard-exit for all users if the utility chain halts to reclaim their equivalent part of the Simple Token stake on Ethereum (before v1.0)"
+}

--- a/docs/json/Core.json
+++ b/docs/json/Core.json
@@ -1,0 +1,18 @@
+
+{
+   "methods" : {
+      "chainIdRemote()" : {
+         "details" : "Returns ID of remote chain",
+         "return" : "uint256"
+      },
+      "openSTRemote()" : {
+         "details" : "Returns protocol on remote chain",
+         "return" : "address"
+      },
+      "registrar()" : {
+         "details" : "Returns registrar",
+         "return" : "address"
+      }
+   },
+   "title" : "Core - A minimal stub that will become the anchoring and consensus point for the utility chain to validate itself against"
+}

--- a/docs/json/CoreInterface.json
+++ b/docs/json/CoreInterface.json
@@ -1,0 +1,19 @@
+
+{
+   "methods" : {
+      "chainIdRemote()" : {
+         "details" : "Returns ID of remote chain",
+         "return" : "uint256"
+      },
+      "openSTRemote()" : {
+         "details" : "Returns protocol on remote chain",
+         "return" : "address"
+      },
+      "registrar()" : {
+         "details" : "Returns registrar",
+         "return" : "address"
+      }
+   },
+   "title" : "CoreInterface - Interface for Core"
+}
+

--- a/docs/json/EIP20Interface.json
+++ b/docs/json/EIP20Interface.json
@@ -1,0 +1,63 @@
+
+{
+   "methods" : {
+      "allowance(address,address)" : {
+         "details" : "Returns remaining allowance of _spender from _owner",
+         "params" : {
+            "_owner" : "owner",
+            "_spender" : "spender"
+         },
+         "return" : "remaining"
+      },
+      "approve(address,uint256)" : {
+         "details" : "Approves _spender to transfer _value from msg.sender; emits Approval event",
+         "params" : {
+            "_spender" : "spender",
+            "_value" : "value"
+         },
+         "return" : "success"
+      },
+      "balanceOf(address)" : {
+         "details" : "Returns balance of _owner",
+         "params" : {
+            "_owner" : "owner"
+         },
+         "return" : "balance"
+      },
+      "decimals()" : {
+         "details" : "Returns decimals",
+         "return" : "uint8"
+      },
+      "name()" : {
+         "details" : "Returns name",
+         "return" : "string"
+      },
+      "symbol()" : {
+         "details" : "Returns symbol",
+         "return" : "string"
+      },
+      "totalSupply()" : {
+         "details" : "Returns totalSupply",
+         "return" : "uint256"
+      },
+      "transfer(address,uint256)" : {
+         "details" : "Transfers _value from balance of msg.sender to _to; emits Transfer event",
+         "params" : {
+            "_to" : "to",
+            "_value" : "value"
+         },
+         "return" : "success"
+      },
+      "transferFrom(address,address,uint256)" : {
+         "details" : "Transfers _value from balance of _from to _to; emits Transfer event",
+         "params" : {
+            "_from" : "from",
+            "_to" : "to",
+            "_value" : "value"
+         },
+         "return" : "success"
+      }
+   },
+   "title" : "EIP20Interface - Interface for EIP20Token"
+}
+

--- a/docs/json/EIP20Token.json
+++ b/docs/json/EIP20Token.json
@@ -1,0 +1,62 @@
+
+{
+   "methods" : {
+      "allowance(address,address)" : {
+         "details" : "Takes _owner, _spender; returns remaining allowance of _spender from _owner",
+         "params" : {
+            "_owner" : "owner",
+            "_spender" : "spender"
+         },
+         "return" : "remaining"
+      },
+      "approve(address,uint256)" : {
+         "details" : "Takes _spender, _value; approves _spender to transfer _value from msg.sender; emits Approval event",
+         "params" : {
+            "_spender" : "spender",
+            "_value" : "value"
+         },
+         "return" : "success"
+      },
+      "balanceOf(address)" : {
+         "details" : "Takes _owner; returns balance of _owner",
+         "params" : {
+            "_owner" : "owner"
+         },
+         "return" : "balance"
+      },
+      "decimals()" : {
+         "details" : "Returns decimals",
+         "return" : "uint8"
+      },
+      "name()" : {
+         "details" : "Returns name",
+         "return" : "string"
+      },
+      "symbol()" : {
+         "details" : "Returns symbol",
+         "return" : "string"
+      },
+      "totalSupply()" : {
+         "details" : "Returns totalSupply",
+         "return" : "uint256"
+      },
+      "transfer(address,uint256)" : {
+         "details" : "Takes _to, _value; transfers _value from balance of msg.sender to _to; emits Transfer event",
+         "params" : {
+            "_to" : "to",
+            "_value" : "value"
+         },
+         "return" : "success"
+      },
+      "transferFrom(address,address,uint256)" : {
+         "details" : "Takes _from, _to, _value; transfers _value from balance of _from to _to; emits Transfer event",
+         "params" : {
+            "_from" : "from",
+            "_to" : "to",
+            "_value" : "value"
+         },
+         "return" : "success"
+      }
+   },
+   "title" : "EIP20Token - Implements EIP20 token"
+}

--- a/docs/json/EIP20TokenMock.json
+++ b/docs/json/EIP20TokenMock.json
@@ -1,0 +1,83 @@
+
+{
+   "methods" : {
+      "allowance(address,address)" : {
+         "details" : "Takes _owner, _spender; returns remaining allowance of _spender from _owner",
+         "params" : {
+            "_owner" : "owner",
+            "_spender" : "spender"
+         },
+         "return" : "remaining"
+      },
+      "approve(address,uint256)" : {
+         "details" : "Takes _spender, _value; approves _spender to transfer _value from msg.sender; emits Approval event",
+         "params" : {
+            "_spender" : "spender",
+            "_value" : "value"
+         },
+         "return" : "success"
+      },
+      "balanceOf(address)" : {
+         "details" : "Takes _owner; returns balance of _owner",
+         "params" : {
+            "_owner" : "owner"
+         },
+         "return" : "balance"
+      },
+      "burnEIP20Public(uint256)" : {
+         "details" : "Public wrapper for burnEIP20Public",
+         "params" : {
+            "_amount" : "amount"
+         },
+         "return" : "success bool"
+      },
+      "claimEIP20Public(address,uint256)" : {
+         "details" : "Public wrapper for claimEIP20Public",
+         "params" : {
+            "_amount" : "amount",
+            "_beneficiary" : "beneficiary"
+         },
+         "return" : "success bool"
+      },
+      "decimals()" : {
+         "details" : "Returns decimals",
+         "return" : "uint8"
+      },
+      "mintEIP20Public(uint256)" : {
+         "details" : "Public wrapper for mintEIP20Public",
+         "params" : {
+            "_amount" : "amount"
+         },
+         "return" : "success bool"
+      },
+      "name()" : {
+         "details" : "Returns name",
+         "return" : "string"
+      },
+      "symbol()" : {
+         "details" : "Returns symbol",
+         "return" : "string"
+      },
+      "totalSupply()" : {
+         "details" : "Mock totalSupply function"
+      },
+      "transfer(address,uint256)" : {
+         "details" : "Takes _to, _value; transfers _value from balance of msg.sender to _to; emits Transfer event",
+         "params" : {
+            "_to" : "to",
+            "_value" : "value"
+         },
+         "return" : "success"
+      },
+      "transferFrom(address,address,uint256)" : {
+         "details" : "Takes _from, _to, _value; transfers _value from balance of _from to _to; emits Transfer event",
+         "params" : {
+            "_from" : "from",
+            "_to" : "to",
+            "_value" : "value"
+         },
+         "return" : "success"
+      }
+   },
+   "title" : "EIP20TokenMock - Implements mock totalSupply function and wraps internal functions to enable testing EIP20Token"
+}

--- a/docs/json/Hasher.json
+++ b/docs/json/Hasher.json
@@ -1,0 +1,43 @@
+
+{
+   "methods" : {
+      "hashRedemptionIntent(bytes32,address,uint256,uint256,uint256)" : {
+         "details" : "Returns hash of _uuid, _account, _accountNonce, _amountUT, _escrowUnlockHeight",
+         "params" : {
+            "_account" : "account",
+            "_accountNonce" : "accountNonce",
+            "_amountUT" : "amountUT",
+            "_escrowUnlockHeight" : "escrowUnlockHeight",
+            "_uuid" : "uuid"
+         },
+         "return" : "bytes32"
+      },
+      "hashStakingIntent(bytes32,address,uint256,address,uint256,uint256,uint256)" : {
+         "details" : "Returns hash of _uuid, _account, _accountNonce, _beneficiary, _amountST, _amountUT, _escrowUnlockHeight",
+         "params" : {
+            "_account" : "account",
+            "_accountNonce" : "accountNonce",
+            "_amountST" : "amountST",
+            "_amountUT" : "amountUT",
+            "_beneficiary" : "beneficiary",
+            "_escrowUnlockHeight" : "escrowUnlockHeight",
+            "_uuid" : "uuid"
+         },
+         "return" : "bytes32"
+      },
+      "hashUuid(string,string,uint256,uint256,address,uint256)" : {
+         "details" : "Returns hash of _symbol, _name, _chainIdValue, _chainIdUtility, _openSTUtility, _conversionRate",
+         "params" : {
+            "_chainIdUtility" : "chainIdUtility",
+            "_chainIdValue" : "chainIdValue",
+            "_conversionRate" : "conversionRate",
+            "_name" : "name",
+            "_openSTUtility" : "openSTUtility",
+            "_symbol" : "symbol"
+         },
+         "return" : "bytes32"
+      }
+   },
+   "title" : "Hasher - Protocol hash functions"
+}
+

--- a/docs/json/OpenSTUtility.json
+++ b/docs/json/OpenSTUtility.json
@@ -1,0 +1,176 @@
+
+{
+   "methods" : {
+      "checkAvailability(bytes32,bytes32,address)" : {
+         "details" : "Takes _hashSymbol, _hashName, _requester; checks whether branded token is available",
+         "params" : {
+            "_hashName" : "hashName",
+            "_hashSymbol" : "hashSymbol",
+            "_requester" : "requester"
+         },
+         "return" : "bool"
+      },
+      "completeOwnershipTransfer()" : {
+         "details" : "Sets proposedOwner to owner and proposedOwner to 0; only callable by proposedOwner; emits OwnershipTransferCompleted event",
+         "return" : "success bool"
+      },
+      "confirmStakingIntent(bytes32,address,uint256,address,uint256,uint256,uint256,bytes32)" : {
+         "details" : "Takes _uuid, _staker, _stakerNonce, _beneficiary, _amountST, _amountUT, _stakingUnlockHeight, _stakingIntentHash; confirms staking intent; emits StakingIntentConfirmed event; only callable by registrar",
+         "params" : {
+            "_amountST" : "amountST",
+            "_amountUT" : "amountUT",
+            "_beneficiary" : "beneficiary",
+            "_staker" : "staker",
+            "_stakerNonce" : "stakerNonce",
+            "_stakingIntentHash" : "stakingIntentHash",
+            "_stakingUnlockHeight" : "stakingUnlockHeight",
+            "_uuid" : "uuid"
+         },
+         "return" : "expirationHeight"
+      },
+      "hashRedemptionIntent(bytes32,address,uint256,uint256,uint256)" : {
+         "details" : "Returns hash of _uuid, _account, _accountNonce, _amountUT, _escrowUnlockHeight",
+         "params" : {
+            "_account" : "account",
+            "_accountNonce" : "accountNonce",
+            "_amountUT" : "amountUT",
+            "_escrowUnlockHeight" : "escrowUnlockHeight",
+            "_uuid" : "uuid"
+         },
+         "return" : "bytes32"
+      },
+      "hashStakingIntent(bytes32,address,uint256,address,uint256,uint256,uint256)" : {
+         "details" : "Returns hash of _uuid, _account, _accountNonce, _beneficiary, _amountST, _amountUT, _escrowUnlockHeight",
+         "params" : {
+            "_account" : "account",
+            "_accountNonce" : "accountNonce",
+            "_amountST" : "amountST",
+            "_amountUT" : "amountUT",
+            "_beneficiary" : "beneficiary",
+            "_escrowUnlockHeight" : "escrowUnlockHeight",
+            "_uuid" : "uuid"
+         },
+         "return" : "bytes32"
+      },
+      "hashUuid(string,string,uint256,uint256,address,uint256)" : {
+         "details" : "Returns hash of _symbol, _name, _chainIdValue, _chainIdUtility, _openSTUtility, _conversionRate",
+         "params" : {
+            "_chainIdUtility" : "chainIdUtility",
+            "_chainIdValue" : "chainIdValue",
+            "_conversionRate" : "conversionRate",
+            "_name" : "name",
+            "_openSTUtility" : "openSTUtility",
+            "_symbol" : "symbol"
+         },
+         "return" : "bytes32"
+      },
+      "initiateOwnershipTransfer(address)" : {
+         "details" : "Takes _proposedOwner; sets proposedOwner to _proposedOwner; only callable by owner; emits OwnershipTransferInitiated event",
+         "params" : {
+            "_proposedOwner" : "proposedOwner"
+         },
+         "return" : "success bool"
+      },
+      "initiateProtocolTransfer(address,address)" : {
+         "details" : "Takes _token, _proposedProtocol; initiates transfer to _proposedProtocol for _token; only callable by adminAddress",
+         "params" : {
+            "_proposedProtocol" : "proposedProtocol",
+            "_token" : "token"
+         },
+         "return" : "success bool"
+      },
+      "processMinting(bytes32)" : {
+         "details" : "Takes _stakingIntentHash; processes corresponding mint; emits ProcessedMint event",
+         "params" : {
+            "_stakingIntentHash" : "stakingIntentHash"
+         },
+         "return" : "tokenAddress"
+      },
+      "processRedeeming(bytes32)" : {
+         "details" : "Takes _redemptionIntentHash; processes corresponding redemption; emits ProcessedRedemption event",
+         "params" : {
+            "_redemptionIntentHash" : "redemptionIntentHash"
+         },
+         "return" : "tokenAddress"
+      },
+      "proposeBrandedToken(string,string,uint256)" : {
+         "details" : "Takes _symbol _name _conversionRate. Congratulations on looking under the hood and obtaining ST' to call proposeBrandedToken; however, OpenSTFoundation is not yet actively listening to these events because to automate it we will build a web UI where you can authenticate with your msg.sender = _requester key; until that time please drop us a line on partners(at)simpletoken.org and we can work with you to register your branded token",
+         "params" : {
+            "_conversionRate" : "conversionRate",
+            "_name" : "name",
+            "_symbol" : "symbol"
+         },
+         "return" : "btUuid"
+      },
+      "redeem(bytes32,uint256,uint256)" : {
+         "details" : "Takes _uuid, _amountBT, _nonce; redeemer must set an allowance for the branded token with OpenSTUtility as the spender so that the branded token can be taken into escrow by OpenSTUtility; emits RedemptionIntentDeclared event. Note: for STPrime, call OpenSTUtility.redeemSTPrime as a payable function. Note: nonce must be queried from OpenSTValue contract",
+         "params" : {
+            "_amountBT" : "amountBT",
+            "_nonce" : "nonce",
+            "_uuid" : "uuid"
+         },
+         "return" : "unlockHeight, redemptionIntentHash"
+      },
+      "redeemSTPrime(uint256)" : {
+         "details" : "Takes _nonce; redeemer must send as value the amount STP to redeem; emits RedemptionIntentDeclared event. Note: nonce must be queried from OpenSTValue contract",
+         "params" : {
+            "_nonce" : "nonce"
+         },
+         "return" : "amountSTP, unlockHeight, redemptionIntentHash"
+      },
+      "registerBrandedToken(string,string,uint256,address,address,bytes32)" : {
+         "details" : "Takes _symbol, _name, _conversionRate, _requester, _brandedToken, _checkUuid; registers a branded token; emits RegisteredBrandedToken event; only callable by registrar",
+         "params" : {
+            "_brandedToken" : "brandedToken",
+            "_checkUuid" : "checkUuid",
+            "_conversionRate" : "conversionRate",
+            "_name" : "name",
+            "_requester" : "requester",
+            "_symbol" : "symbol"
+         },
+         "return" : "registeredUuid"
+      },
+      "registeredTokenProperties(bytes32)" : {
+         "params" : {
+            "_uuid" : "uuid"
+         },
+         "return" : "token address, registrar address"
+      },
+      "revertMinting(bytes32)" : {
+         "details" : "Takes _stakingIntentHash; reverts corresponding mint; emits RevertedMint event",
+         "params" : {
+            "_stakingIntentHash" : "stakingIntentHash"
+         },
+         "return" : "uuid, staker, beneficiary, amount"
+      },
+      "revertRedemption(bytes32)" : {
+         "details" : "Takes _redemptionIntentHash; reverts corresponding redemption; emits RevertedRedemption event",
+         "params" : {
+            "_redemptionIntentHash" : "redemptionIntentHash"
+         },
+         "return" : "uuid, redeemer, amountUT"
+      },
+      "revokeProtocolTransfer(address)" : {
+         "details" : "Takes _token; revokes protocol transfer; on the very first released version v0.9.1 there is no need to completeProtocolTransfer from a previous version; only callable by adminAddress",
+         "params" : {
+            "_token" : "token"
+         },
+         "return" : "success bool"
+      },
+      "setAdminAddress(address)" : {
+         "details" : "Takes _adminAddress; sets adminAddress to _adminAddress and returns true; only callable by owner or adminAddress; adminAddress can also be set to 0 to 'disable' it",
+         "params" : {
+            "_adminAddress" : "adminAddress"
+         },
+         "return" : "bool"
+      },
+      "setOpsAddress(address)" : {
+         "details" : "Takes _opsAddress; sets opsAddress to _opsAddress and returns true; only callable by owner or adminAddress; _opsAddress can also be set to 0 to 'disable' it",
+         "params" : {
+            "_opsAddress" : "opsAddress"
+         },
+         "return" : "bool"
+      }
+   },
+   "title" : "OpenSTUtility - Protocol for a utility chain"
+}

--- a/docs/json/OpenSTUtilityInterface.json
+++ b/docs/json/OpenSTUtilityInterface.json
@@ -1,0 +1,39 @@
+
+{
+   "methods" : {
+      "confirmStakingIntent(bytes32,address,uint256,address,uint256,uint256,uint256,bytes32)" : {
+         "details" : "Takes _uuid _staker _stakerNonce _beneficiary _amountST _amountUT _stakingUnlockHeight _stakingIntentHash; confirms staking intent; emits StakingIntentConfirmed event",
+         "params" : {
+            "_amountST" : "amountST",
+            "_amountUT" : "amountUT",
+            "_beneficiary" : "beneficiary",
+            "_staker" : "staker",
+            "_stakerNonce" : "stakerNonce",
+            "_stakingIntentHash" : "stakingIntentHash",
+            "_stakingUnlockHeight" : "stakingUnlockHeight",
+            "_uuid" : "uuid"
+         },
+         "return" : "expirationHeight"
+      },
+      "processRedeeming(bytes32)" : {
+         "details" : "Takes _redemptionIntentHash; processes corresponding redemption; emits ProcessedRedemption event",
+         "params" : {
+            "_redemptionIntentHash" : "redemptionIntentHash"
+         },
+         "return" : "tokenAddress"
+      },
+      "registerBrandedToken(string,string,uint256,address,address,bytes32)" : {
+         "details" : "Takes _symbol, _name, _conversionRate, _requester, _brandedToken, _checkUuid; registers a branded token; emits RegisteredBrandedToken event",
+         "params" : {
+            "_brandedToken" : "brandedToken",
+            "_checkUuid" : "checkUuid",
+            "_conversionRate" : "conversionRate",
+            "_name" : "name",
+            "_requester" : "requester",
+            "_symbol" : "symbol"
+         },
+         "return" : "registeredUuid"
+      }
+   },
+   "title" : "OpenSTUtilityInterface - Interface for OpenSTUtility"
+}

--- a/docs/json/OpenSTValue.json
+++ b/docs/json/OpenSTValue.json
@@ -1,0 +1,172 @@
+
+{
+   "methods" : {
+      "addCore(address)" : {
+         "details" : "Takes _core; adds _core to cores by core.chainIdRemote; only callable by registrar",
+         "params" : {
+            "_core" : "core"
+         },
+         "return" : "success bool"
+      },
+      "blocksToWaitLong()" : {
+         "details" : "Returns BLOCKS_TO_WAIT_LONG",
+         "return" : "uint256"
+      },
+      "blocksToWaitShort()" : {
+         "details" : "Returns BLOCKS_TO_WAIT_SHORT",
+         "return" : "uint256"
+      },
+      "completeOwnershipTransfer()" : {
+         "details" : "Sets proposedOwner to owner and proposedOwner to 0; only callable by proposedOwner; emits OwnershipTransferCompleted event",
+         "return" : "success bool"
+      },
+      "confirmRedemptionIntent(bytes32,address,uint256,uint256,uint256,bytes32)" : {
+         "details" : "Takes _uuid, _redeemer, _redeemerNonce, _amountUT, _redemptionUnlockHeight, _redemptionIntentHash; confirms redemption intent; emits RedemptionIntentConfirmed event; only callable by registrar",
+         "params" : {
+            "_amountUT" : "amountUT",
+            "_redeemer" : "redeemer",
+            "_redeemerNonce" : "redeemerNonce",
+            "_redemptionIntentHash" : "redemptionIntentHash",
+            "_redemptionUnlockHeight" : "redemptionUnlockHeight",
+            "_uuid" : "uuid"
+         },
+         "return" : "amountST, expirationHeight"
+      },
+      "core(uint256)" : {
+         "details" : "Takes _chainIdUtility; returns core address",
+         "return" : "address"
+      },
+      "getNextNonce(address)" : {
+         "details" : "Takes _account; returns next nonce",
+         "return" : "uint256"
+      },
+      "hashRedemptionIntent(bytes32,address,uint256,uint256,uint256)" : {
+         "details" : "Returns hash of _uuid, _account, _accountNonce, _amountUT, _escrowUnlockHeight",
+         "params" : {
+            "_account" : "account",
+            "_accountNonce" : "accountNonce",
+            "_amountUT" : "amountUT",
+            "_escrowUnlockHeight" : "escrowUnlockHeight",
+            "_uuid" : "uuid"
+         },
+         "return" : "bytes32"
+      },
+      "hashStakingIntent(bytes32,address,uint256,address,uint256,uint256,uint256)" : {
+         "details" : "Returns hash of _uuid, _account, _accountNonce, _beneficiary, _amountST, _amountUT, _escrowUnlockHeight",
+         "params" : {
+            "_account" : "account",
+            "_accountNonce" : "accountNonce",
+            "_amountST" : "amountST",
+            "_amountUT" : "amountUT",
+            "_beneficiary" : "beneficiary",
+            "_escrowUnlockHeight" : "escrowUnlockHeight",
+            "_uuid" : "uuid"
+         },
+         "return" : "bytes32"
+      },
+      "hashUuid(string,string,uint256,uint256,address,uint256)" : {
+         "details" : "Returns hash of _symbol, _name, _chainIdValue, _chainIdUtility, _openSTUtility, _conversionRate",
+         "params" : {
+            "_chainIdUtility" : "chainIdUtility",
+            "_chainIdValue" : "chainIdValue",
+            "_conversionRate" : "conversionRate",
+            "_name" : "name",
+            "_openSTUtility" : "openSTUtility",
+            "_symbol" : "symbol"
+         },
+         "return" : "bytes32"
+      },
+      "initiateOwnershipTransfer(address)" : {
+         "details" : "Takes _proposedOwner; sets proposedOwner to _proposedOwner; only callable by owner; emits OwnershipTransferInitiated event",
+         "params" : {
+            "_proposedOwner" : "proposedOwner"
+         },
+         "return" : "success bool"
+      },
+      "initiateProtocolTransfer(address,address)" : {
+         "details" : "Takes _simpleStake, _proposedProtocol; initiates transfer to _proposedProtocol for _simpleStake; only callable by adminAddress",
+         "params" : {
+            "_proposedProtocol" : "proposedProtocol",
+            "_simpleStake" : "simpleStake"
+         },
+         "return" : "success bool"
+      },
+      "processStaking(bytes32)" : {
+         "details" : "Takes _stakingIntentHash; processes corresponding stake; emits ProcessedStake event",
+         "params" : {
+            "_stakingIntentHash" : "stakingIntentHash"
+         },
+         "return" : "stakeAddress"
+      },
+      "processUnstaking(bytes32)" : {
+         "details" : "Takes _redemptionIntentHash; processes corresponding unstake; emits ProcessedUnstake event",
+         "params" : {
+            "_redemptionIntentHash" : "redemptionIntentHash"
+         },
+         "return" : "stakeAddress"
+      },
+      "registerUtilityToken(string,string,uint256,uint256,address,bytes32)" : {
+         "details" : "Takes _symbol, _name, _conversionRate, _chainIdUtility, _stakingAccount, _checkUuid; registers a utility token; emits UtilityTokenRegistered event; only callable by registrar",
+         "params" : {
+            "_chainIdUtility" : "chainIdUtility",
+            "_checkUuid" : "checkUuid",
+            "_conversionRate" : "conversionRate",
+            "_name" : "name",
+            "_stakingAccount" : "stakingAccount",
+            "_symbol" : "symbol"
+         },
+         "return" : "uuid"
+      },
+      "revertStaking(bytes32)" : {
+         "details" : "Takes _stakingIntentHash; reverts corresponding stake; emits RevertedStake event",
+         "params" : {
+            "_stakingIntentHash" : "stakingIntentHash"
+         },
+         "return" : "uuid, staker, amountST, staker"
+      },
+      "revertUnstaking(bytes32)" : {
+         "details" : "Takes _redemptionIntentHash; reverts corresponding unstake; emits RevertedUnstake event",
+         "params" : {
+            "_redemptionIntentHash" : "redemptionIntentHash"
+         },
+         "return" : "uuid, redeemer, amountST"
+      },
+      "revokeProtocolTransfer(address)" : {
+         "details" : "Takes _simpleStake; revokes protocol transfer; on the very first released version v0.9.1 there is no need to completeProtocolTransfer from a previous version; only callable by adminAddress",
+         "params" : {
+            "_simpleStake" : "simpleStake"
+         },
+         "return" : "success bool"
+      },
+      "setAdminAddress(address)" : {
+         "details" : "Takes _adminAddress; sets adminAddress to _adminAddress and returns true; only callable by owner or adminAddress; adminAddress can also be set to 0 to 'disable' it",
+         "params" : {
+            "_adminAddress" : "adminAddress"
+         },
+         "return" : "bool"
+      },
+      "setOpsAddress(address)" : {
+         "details" : "Takes _opsAddress; sets opsAddress to _opsAddress and returns true; only callable by owner or adminAddress; _opsAddress can also be set to 0 to 'disable' it",
+         "params" : {
+            "_opsAddress" : "opsAddress"
+         },
+         "return" : "bool"
+      },
+      "stake(bytes32,uint256,address)" : {
+         "details" : "Takes _uuid, _amountST, _beneficiary; In order to stake the tx.origin needs to set an allowance for the OpenSTValue contract to transfer to itself to hold during the staking process.",
+         "params" : {
+            "_amountST" : "amountST",
+            "_beneficiary" : "beneficiary",
+            "_uuid" : "uuid"
+         },
+         "return" : "amountUT, nonce, unlockHeight, stakingIntentHash"
+      },
+      "utilityTokenProperties(bytes32)" : {
+         "params" : {
+            "_uuid" : "uuid"
+         },
+         "return" : "symbol, name, conversionRate, decimals, chainIdUtility, simpleStake, stakingAccount"
+      }
+   },
+   "title" : "OpenSTValue - value staking contract for OpenST "
+}

--- a/docs/json/OpenSTValueInterface.json
+++ b/docs/json/OpenSTValueInterface.json
@@ -1,0 +1,45 @@
+
+{
+   "methods" : {
+      "addCore(address)" : {
+         "details" : "Takes _core; adds _core to cores by core.chainIdRemote",
+         "params" : {
+            "_core" : "core"
+         },
+         "return" : "success bool"
+      },
+      "confirmRedemptionIntent(bytes32,address,uint256,uint256,uint256,bytes32)" : {
+         "details" : "Takes _uuid, _redeemer, _redeemerNonce, _amountUT, _redemptionUnlockHeight, _redemptionIntentHash; confirms redemption intent; emits RedemptionIntentConfirmed event",
+         "params" : {
+            "_amountUT" : "amountUT",
+            "_redeemer" : "redeemer",
+            "_redeemerNonce" : "redeemerNonce",
+            "_redemptionIntentHash" : "redemptionIntentHash",
+            "_redemptionUnlockHeight" : "redemptionUnlockHeight",
+            "_uuid" : "uuid"
+         },
+         "return" : "amountST, expirationHeight"
+      },
+      "processStaking(bytes32)" : {
+         "details" : "Takes _stakingIntentHash; processes corresponding stake; emits ProcessedStake event",
+         "params" : {
+            "_stakingIntentHash" : "stakingIntentHash"
+         },
+         "return" : "stakeAddress"
+      },
+      "registerUtilityToken(string,string,uint256,uint256,address,bytes32)" : {
+         "details" : "Takes _symbol, _name, _conversionRate, _chainIdUtility, _stakingAccount, _checkUuid; registers a utility token; emits UtilityTokenRegistered event",
+         "params" : {
+            "_chainIdUtility" : "chainIdUtility",
+            "_checkUuid" : "checkUuid",
+            "_conversionRate" : "conversionRate",
+            "_name" : "name",
+            "_stakingAccount" : "stakingAccount",
+            "_symbol" : "symbol"
+         },
+         "return" : "uuid"
+      }
+   },
+   "title" : "OpenSTValueInterface - Interface for OpenSTValue"
+}
+

--- a/docs/json/OpsManaged.json
+++ b/docs/json/OpsManaged.json
@@ -1,0 +1,31 @@
+
+{
+   "methods" : {
+      "completeOwnershipTransfer()" : {
+         "details" : "Sets proposedOwner to owner and proposedOwner to 0; only callable by proposedOwner; emits OwnershipTransferCompleted event",
+         "return" : "success bool"
+      },
+      "initiateOwnershipTransfer(address)" : {
+         "details" : "Takes _proposedOwner; sets proposedOwner to _proposedOwner; only callable by owner; emits OwnershipTransferInitiated event",
+         "params" : {
+            "_proposedOwner" : "proposedOwner"
+         },
+         "return" : "success bool"
+      },
+      "setAdminAddress(address)" : {
+         "details" : "Takes _adminAddress; sets adminAddress to _adminAddress and returns true; only callable by owner or adminAddress; adminAddress can also be set to 0 to 'disable' it",
+         "params" : {
+            "_adminAddress" : "adminAddress"
+         },
+         "return" : "bool"
+      },
+      "setOpsAddress(address)" : {
+         "details" : "Takes _opsAddress; sets opsAddress to _opsAddress and returns true; only callable by owner or adminAddress; _opsAddress can also be set to 0 to 'disable' it",
+         "params" : {
+            "_opsAddress" : "opsAddress"
+         },
+         "return" : "bool"
+      }
+   },
+   "title" : "OpsManaged - OpenST ownership and permission model"
+}

--- a/docs/json/Owned.json
+++ b/docs/json/Owned.json
@@ -1,0 +1,18 @@
+
+{
+   "methods" : {
+      "completeOwnershipTransfer()" : {
+         "details" : "Sets proposedOwner to owner and proposedOwner to 0; only callable by proposedOwner; emits OwnershipTransferCompleted event",
+         "return" : "success bool"
+      },
+      "initiateOwnershipTransfer(address)" : {
+         "details" : "Takes _proposedOwner; sets proposedOwner to _proposedOwner; only callable by owner; emits OwnershipTransferInitiated event",
+         "params" : {
+            "_proposedOwner" : "proposedOwner"
+         },
+         "return" : "success bool"
+      }
+   },
+   "title" : "Owned - Implements basic ownership with 2-step transfers"
+}
+

--- a/docs/json/ProtocolVersioned.json
+++ b/docs/json/ProtocolVersioned.json
@@ -1,0 +1,22 @@
+
+{
+   "methods" : {
+      "completeProtocolTransfer()" : {
+         "details" : "Only after the waiting period, can proposed protocol complete the transfer; emits ProtocolTransferCompleted event; only callable by proposed protocol",
+         "return" : "success bool"
+      },
+      "initiateProtocolTransfer(address)" : {
+         "details" : "Takes _proposedProtocol; initiates protocol transfer; emits ProtocolTransferInitiated event; only callable by protocol",
+         "params" : {
+            "_proposedProtocol" : "proposedProtocol"
+         },
+         "return" : "success bool"
+      },
+      "revokeProtocolTransfer()" : {
+         "details" : "protocol can revoke initiated protocol transfer; emits ProtocolTransferRevoked event; only callable by protocol",
+         "return" : "success bool"
+      }
+   },
+   "title" : "ProtocolVersioned - Administers protocol versioning"
+}
+

--- a/docs/json/Registrar.json
+++ b/docs/json/Registrar.json
@@ -1,0 +1,109 @@
+
+{
+   "methods" : {
+      "addCore(address,address)" : {
+         "details" : "Takes _registry, _core; adds _core to _registry; only callable by adminAddress or opsAddress",
+         "params" : {
+            "_core" : "core",
+            "_registry" : "registry"
+         },
+         "return" : "success bool"
+      },
+      "completeOwnershipTransfer()" : {
+         "details" : "Sets proposedOwner to owner and proposedOwner to 0; only callable by proposedOwner; emits OwnershipTransferCompleted event",
+         "return" : "success bool"
+      },
+      "confirmRedemptionIntent(address,bytes32,address,uint256,uint256,uint256,bytes32)" : {
+         "details" : "Takes __registry, uuid, _redeemer, _redeemerNonce, _amountUT, _redemptionUnlockHeight, _redemptionIntentHash; confirms redemption intent with _registry; only callable by opsAddress",
+         "params" : {
+            "_amountUT" : "amountUT",
+            "_redeemer" : "redeemer",
+            "_redeemerNonce" : "redeemerNonce",
+            "_redemptionIntentHash" : "redemptionIntentHash",
+            "_redemptionUnlockHeight" : "redemptionUnlockHeight",
+            "_registry" : "registry",
+            "_uuid" : "uuid"
+         },
+         "return" : "amountST, expirationHeight"
+      },
+      "confirmStakingIntent(address,bytes32,address,uint256,address,uint256,uint256,uint256,bytes32)" : {
+         "details" : "Takes _registry, _uuid, _staker, _stakerNonce, _beneficiary, _amountST, _amountUT, _stakingUnlockHeight, _stakingIntentHash; confirms staking intent with _registry; only callable by opsAddress",
+         "params" : {
+            "_amountST" : "amountST",
+            "_amountUT" : "amountUT",
+            "_beneficiary" : "beneficiary",
+            "_registry" : "registry",
+            "_staker" : "staker",
+            "_stakerNonce" : "stakerNonce",
+            "_stakingIntentHash" : "stakingIntentHash",
+            "_stakingUnlockHeight" : "stakingUnlockHeight",
+            "_uuid" : "uuid"
+         },
+         "return" : "expirationHeight"
+      },
+      "initiateOwnershipTransfer(address)" : {
+         "details" : "Takes _proposedOwner; sets proposedOwner to _proposedOwner; only callable by owner; emits OwnershipTransferInitiated event",
+         "params" : {
+            "_proposedOwner" : "proposedOwner"
+         },
+         "return" : "success bool"
+      },
+      "processRedeeming(address,bytes32)" : {
+         "details" : "Takes _registry, _redemptionIntentHash; processes corresponding redemption with _registry; only callable by adminAddress",
+         "params" : {
+            "_redemptionIntentHash" : "redemptionIntentHash",
+            "_registry" : "registry"
+         },
+         "return" : "tokenAddress"
+      },
+      "processStaking(address,bytes32)" : {
+         "details" : "Takes _registry, _stakingIntentHash; processes stake with _registry; only callable by adminAddress",
+         "params" : {
+            "_registry" : "registry",
+            "_stakingIntentHash" : "stakingIntentHash"
+         },
+         "return" : "stakeAddress"
+      },
+      "registerBrandedToken(address,string,string,uint256,address,address,bytes32)" : {
+         "details" : "Takes _registry, _symbol, _name, _conversionRate, _requester, _brandedToken, _checkUuid; registers a branded token with _registry; only callable by adminAddress or opsAddress",
+         "params" : {
+            "_brandedToken" : "brandedToken",
+            "_checkUuid" : "checkUuid",
+            "_conversionRate" : "conversionRate",
+            "_name" : "name",
+            "_registry" : "registry",
+            "_requester" : "requester",
+            "_symbol" : "symbol"
+         },
+         "return" : "registeredUuid"
+      },
+      "registerUtilityToken(address,string,string,uint256,uint256,address,bytes32)" : {
+         "details" : "Takes _registry, _symbol, _name, _conversionRate, _chainIdUtility, _stakingAccount, _checkUuid; registers a utility token with _registry; only callable by adminAddress or opsAddress",
+         "params" : {
+            "_chainIdUtility" : "chainIdUtility",
+            "_checkUuid" : "checkUuid",
+            "_conversionRate" : "conversionRate",
+            "_name" : "name",
+            "_registry" : "registry",
+            "_stakingAccount" : "stakingAccount",
+            "_symbol" : "symbol"
+         },
+         "return" : "uuid"
+      },
+      "setAdminAddress(address)" : {
+         "details" : "Takes _adminAddress; sets adminAddress to _adminAddress and returns true; only callable by owner or adminAddress; adminAddress can also be set to 0 to 'disable' it",
+         "params" : {
+            "_adminAddress" : "adminAddress"
+         },
+         "return" : "bool"
+      },
+      "setOpsAddress(address)" : {
+         "details" : "Takes _opsAddress; sets opsAddress to _opsAddress and returns true; only callable by owner or adminAddress; _opsAddress can also be set to 0 to 'disable' it",
+         "params" : {
+            "_opsAddress" : "opsAddress"
+         },
+         "return" : "bool"
+      }
+   },
+   "title" : "Registrar - Administers registrations for utility tokens"
+}

--- a/docs/json/STPrime.json
+++ b/docs/json/STPrime.json
@@ -1,0 +1,61 @@
+
+{
+   "methods" : {
+      "burn(address,uint256)" : {
+         "details" : "Takes _burner, _amount; burns utility tokens after having redeemed them through the protocol for the staked Simple Token; only callable by protocol",
+         "params" : {
+            "_amount" : "amount",
+            "_burner" : "burner"
+         },
+         "return" : "bool"
+      },
+      "claim(address)" : {
+         "details" : "Takes _beneficiary; transfers full claim to beneficiary; claim can be called publicly as the beneficiary and amount are set, and this allows for reduced steps on the user experience to complete the claim automatically; for first stake of ST' the gas price by one validator has to be zero to deploy the contracts and accept the very first staking of ST for ST' and its protocol executions.",
+         "params" : {
+            "_beneficiary" : "beneficiary"
+         },
+         "return" : "success bool"
+      },
+      "completeProtocolTransfer()" : {
+         "details" : "Only after the waiting period, can proposed protocol complete the transfer; emits ProtocolTransferCompleted event; only callable by proposed protocol",
+         "return" : "success bool"
+      },
+      "initialize()" : {
+         "details" : "On setup of the utility chain the base tokens need to be transfered in full to STPrime for the base tokens to be minted as ST'"
+      },
+      "initiateProtocolTransfer(address)" : {
+         "details" : "Takes _proposedProtocol; initiates protocol transfer; emits ProtocolTransferInitiated event; only callable by protocol",
+         "params" : {
+            "_proposedProtocol" : "proposedProtocol"
+         },
+         "return" : "success bool"
+      },
+      "mint(address,uint256)" : {
+         "details" : "Takes _beneficiary, _amount; mints new Simple Token Prime into circulation and increase total supply accordingly; tokens are minted into a claim to ensure that the protocol completion does not continue into foreign contracts at _beneficiary; only callable by protocol",
+         "params" : {
+            "_amount" : "amount return bool",
+            "_beneficiary" : "beneficiary"
+         }
+      },
+      "revokeProtocolTransfer()" : {
+         "details" : "protocol can revoke initiated protocol transfer; emits ProtocolTransferRevoked event; only callable by protocol",
+         "return" : "success bool"
+      },
+      "totalSupply()" : {
+         "details" : "Get totalTokenSupply as view so that child cannot edit",
+         "return" : "uint256"
+      },
+      "unclaimed(address)" : {
+         "details" : "Takes _beneficiary; returns unclaimed amount for _beneficiary",
+         "params" : {
+            "_beneficiary" : "beneficiary"
+         },
+         "return" : "uint256"
+      },
+      "uuid()" : {
+         "details" : "Returns uuid",
+         "return" : "bytes32"
+      }
+   },
+   "title" : "STPrime - A freely tradable equivalent representation of Simple Token [ST] on Ethereum mainnet on the utility chain; STPrime functions as the base token to pay for gas consumption on the utility chain; it is not an EIP20 token, but functions as the genesis guardian of the finite amount of base tokens on the utility chain"
+}

--- a/docs/json/SimpleStake.json
+++ b/docs/json/SimpleStake.json
@@ -1,0 +1,34 @@
+
+{
+   "methods" : {
+      "completeProtocolTransfer()" : {
+         "details" : "Only after the waiting period, can proposed protocol complete the transfer; emits ProtocolTransferCompleted event; only callable by proposed protocol",
+         "return" : "success bool"
+      },
+      "getTotalStake()" : {
+         "details" : "total stake is the balance of the staking contract; accidental transfers directly to SimpleStake bypassing the OpenST protocol will not mint new utility tokens, but will add to the total stake; (accidental) donations can not be prevented",
+         "return" : "uint256"
+      },
+      "initiateProtocolTransfer(address)" : {
+         "details" : "Takes _proposedProtocol; initiates protocol transfer; emits ProtocolTransferInitiated event; only callable by protocol",
+         "params" : {
+            "_proposedProtocol" : "proposedProtocol"
+         },
+         "return" : "success bool"
+      },
+      "releaseTo(address,uint256)" : {
+         "details" : "Takes _to, _amount; allows the protocol to release the staked amount into provided address. The protocol MUST be a contract that sets the rules on how the stake can be released and to who. The protocol takes the role of an \"owner\" of the stake. Only callable by protocol. Emits ReleasedStake event.",
+         "params" : {
+            "_amount" : "Amount of stake to release to beneficiary",
+            "_to" : "Beneficiary of the amount of the stake"
+         },
+         "return" : "success bool"
+      },
+      "revokeProtocolTransfer()" : {
+         "details" : "protocol can revoke initiated protocol transfer; emits ProtocolTransferRevoked event; only callable by protocol",
+         "return" : "success bool"
+      }
+   },
+   "title" : "SimpleStake - Stakes the value of an EIP20 token on Ethereum for a utility token on the OpenST platform"
+}
+

--- a/docs/json/UtilityTokenAbstract.json
+++ b/docs/json/UtilityTokenAbstract.json
@@ -1,0 +1,59 @@
+
+{
+   "methods" : {
+      "burn(address,uint256)" : {
+         "details" : "Takes _burner, _amount; burns utility tokens after having redeemed them through the protocol for the staked Simple Token",
+         "params" : {
+            "_amount" : "amount",
+            "_burner" : "burner"
+         },
+         "return" : "success"
+      },
+      "claim(address)" : {
+         "details" : "Takes _beneficiary; transfers full claim to beneficiary",
+         "params" : {
+            "_beneficiary" : "beneficiary"
+         },
+         "return" : "success"
+      },
+      "completeProtocolTransfer()" : {
+         "details" : "Only after the waiting period, can proposed protocol complete the transfer; emits ProtocolTransferCompleted event; only callable by proposed protocol",
+         "return" : "success bool"
+      },
+      "initiateProtocolTransfer(address)" : {
+         "details" : "Takes _proposedProtocol; initiates protocol transfer; emits ProtocolTransferInitiated event; only callable by protocol",
+         "params" : {
+            "_proposedProtocol" : "proposedProtocol"
+         },
+         "return" : "success bool"
+      },
+      "mint(address,uint256)" : {
+         "details" : "Takes _beneficiary, _amount; mints new utility tokens",
+         "params" : {
+            "_amount" : "amount",
+            "_beneficiary" : "beneficiary"
+         },
+         "return" : "success"
+      },
+      "revokeProtocolTransfer()" : {
+         "details" : "protocol can revoke initiated protocol transfer; emits ProtocolTransferRevoked event; only callable by protocol",
+         "return" : "success bool"
+      },
+      "totalSupply()" : {
+         "details" : "Get totalTokenSupply as view so that child cannot edit",
+         "return" : "uint256"
+      },
+      "unclaimed(address)" : {
+         "details" : "Takes _beneficiary; returns unclaimed amount for _beneficiary",
+         "params" : {
+            "_beneficiary" : "beneficiary"
+         },
+         "return" : "uint256"
+      },
+      "uuid()" : {
+         "details" : "Returns uuid",
+         "return" : "bytes32"
+      }
+   },
+   "title" : "UtilityTokenAbstract - Base utility token functionality for BrandedTokens and STPrime"
+}

--- a/docs/json/UtilityTokenAbstractMock.json
+++ b/docs/json/UtilityTokenAbstractMock.json
@@ -1,0 +1,82 @@
+
+{
+   "methods" : {
+      "burn(address,uint256)" : {
+         "details" : "Mock burn function",
+         "params" : {
+            "_amount" : "amount",
+            "_redeemer" : "redeemer"
+         },
+         "return" : "success bool"
+      },
+      "burnInternalPublic(address,uint256)" : {
+         "details" : "Public wrapper for burnInternal",
+         "params" : {
+            "_amount" : "amount",
+            "_redeemer" : "redeemer"
+         },
+         "return" : "success bool"
+      },
+      "claim(address)" : {
+         "details" : "Mock claim function",
+         "params" : {
+            "_beneficiary" : "beneficiary"
+         },
+         "return" : "success bool"
+      },
+      "claimInternalPublic(address)" : {
+         "details" : "Public wrapper for claimInternal",
+         "params" : {
+            "_beneficiary" : "beneficiary"
+         },
+         "return" : "amount"
+      },
+      "completeProtocolTransfer()" : {
+         "details" : "Only after the waiting period, can proposed protocol complete the transfer; emits ProtocolTransferCompleted event; only callable by proposed protocol",
+         "return" : "success bool"
+      },
+      "initiateProtocolTransfer(address)" : {
+         "details" : "Takes _proposedProtocol; initiates protocol transfer; emits ProtocolTransferInitiated event; only callable by protocol",
+         "params" : {
+            "_proposedProtocol" : "proposedProtocol"
+         },
+         "return" : "success bool"
+      },
+      "mint(address,uint256)" : {
+         "details" : "Mock mint function",
+         "params" : {
+            "_amount" : "amount",
+            "_beneficiary" : "beneficiary"
+         },
+         "return" : "success bool"
+      },
+      "mintInternalPublic(address,uint256)" : {
+         "details" : "Public wrapper for mintInternal",
+         "params" : {
+            "_amount" : "amount",
+            "_beneficiary" : "beneficiary"
+         },
+         "return" : "success bool"
+      },
+      "revokeProtocolTransfer()" : {
+         "details" : "protocol can revoke initiated protocol transfer; emits ProtocolTransferRevoked event; only callable by protocol",
+         "return" : "success bool"
+      },
+      "totalSupply()" : {
+         "details" : "Get totalTokenSupply as view so that child cannot edit",
+         "return" : "uint256"
+      },
+      "unclaimed(address)" : {
+         "details" : "Takes _beneficiary; returns unclaimed amount for _beneficiary",
+         "params" : {
+            "_beneficiary" : "beneficiary"
+         },
+         "return" : "uint256"
+      },
+      "uuid()" : {
+         "details" : "Returns uuid",
+         "return" : "bytes32"
+      }
+   },
+   "title" : "UtilityTokenAbstractMock - Implements mock claim, mint, and burn functions and wraps internal functions to enable testing UtilityTokenAbstract"
+}

--- a/docs/json/UtilityTokenInterface.json
+++ b/docs/json/UtilityTokenInterface.json
@@ -1,0 +1,38 @@
+
+{
+   "methods" : {
+      "burn(address,uint256)" : {
+         "details" : "Takes _burner, _amount; burns utility tokens after having redeemed them through the protocol for the staked Simple Token",
+         "params" : {
+            "_amount" : "amount",
+            "_burner" : "burner"
+         },
+         "return" : "success"
+      },
+      "claim(address)" : {
+         "details" : "Takes _beneficiary; transfers full claim to beneficiary",
+         "params" : {
+            "_beneficiary" : "beneficiary"
+         },
+         "return" : "success"
+      },
+      "mint(address,uint256)" : {
+         "details" : "Takes _beneficiary, _amount; mints new utility tokens",
+         "params" : {
+            "_amount" : "amount",
+            "_beneficiary" : "beneficiary"
+         },
+         "return" : "success"
+      },
+      "totalSupply()" : {
+         "details" : "Get totalTokenSupply as view so that child cannot edit",
+         "return" : "supply"
+      },
+      "uuid()" : {
+         "details" : "Get unique universal identifier for utility token",
+         "return" : "getUuid"
+      }
+   },
+   "title" : "UtilityTokenInterface - Interface for UtilityToken"
+}
+

--- a/docs/md/BrandedToken.md
+++ b/docs/md/BrandedToken.md
@@ -1,0 +1,29 @@
+# OpenST Protocol Documentation
+
+## BrandedToken
+
+
+An EIP20 token minted by staking Simple Token on Ethereum mainnet. Branded tokens are designed to be used within a (decentralised) application and support: smart contract controlled password reset for users who don't yet (hard-spoon FTW) manage their own private keys (+v0.9.2); soft-exit for a user to redeem their equivalent part of the Simple Token stake on Ethereum mainnet; hard-exit for all users if the utility chain halts to reclaim their equivalent part of the Simple Token stake on Ethereum (before v1.0)
+
+### Function Summary
+
+Signature | Returns | Details
+--- | --- | ---
+allowance<br/>(address, address) | remaining | Takes _owner, _spender<br/><br/>Returns remaining allowance of _spender from _owner
+approve<br/>(address, uint256) | success | Takes _spender, _value<br/><br/>Approves _spender to transfer _value from msg.sender; emits Approval event
+balanceOf<br/>(address) | balance | Takes _owner<br/><br/>Returns balance of _owner
+burn<br/>(address, uint256) | bool | Takes _burner, _amount<br/><br/>Calls burnEIP20 and returns the result of calling burnInternal; only callable by protocol
+claim<br/>(address) | bool | Takes _beneficiary<br/><br/>Calls claimInternal and returns the result of calling claimEIP20
+completeProtocolTransfer() | success bool | Only after the waiting period, can proposed protocol complete the transfer; emits ProtocolTransferCompleted event; only callable by proposed protocol
+decimals() | uint8 | Returns decimals
+initiateProtocolTransfer<br/>(address) | success bool | Takes _proposedProtocol<br/><br/>Initiates protocol transfer; emits ProtocolTransferInitiated event; only callable by protocol
+mint<br/>(address, uint256) | bool | Takes _beneficiary, _amount<br/><br/>Calls mintEIP20 and returns the result of calling mintInternal; only callable by protocol
+name() | string | Returns name
+revokeProtocolTransfer() | success bool | protocol can revoke initiated protocol transfer; emits ProtocolTransferRevoked event; only callable by protocol
+symbol() | string | Returns symbol
+totalSupply() | uint256 | Get totalTokenSupply as view so that child cannot edit
+transfer<br/>(address, uint256) | success | Takes _to, _value<br/><br/>Transfers _value from balance of msg.sender to _to; emits Transfer event
+transferFrom<br/>(address, address, uint256) | success | Takes _from, _to, _value<br/><br/>Transfers _value from balance of _from to _to; emits Transfer event
+unclaimed<br/>(address) | uint256 | Takes _beneficiary<br/><br/>Returns unclaimed amount for _beneficiary
+uuid() | bytes32 | Returns uuid
+

--- a/docs/md/Core.md
+++ b/docs/md/Core.md
@@ -1,0 +1,15 @@
+# OpenST Protocol Documentation
+
+## Core
+
+
+A minimal stub that will become the anchoring and consensus point for the utility chain to validate itself against
+
+### Function Summary
+
+Signature | Returns | Details
+--- | --- | ---
+chainIdRemote() | uint256 | Returns ID of remote chain
+openSTRemote() | address | Returns protocol on remote chain
+registrar() | address | Returns registrar
+

--- a/docs/md/CoreInterface.md
+++ b/docs/md/CoreInterface.md
@@ -1,0 +1,15 @@
+# OpenST Protocol Documentation
+
+## CoreInterface
+
+
+Interface for Core
+
+### Function Summary
+
+Signature | Returns | Details
+--- | --- | ---
+chainIdRemote() | uint256 | Returns ID of remote chain
+openSTRemote() | address | Returns protocol on remote chain
+registrar() | address | Returns registrar
+

--- a/docs/md/EIP20Interface.md
+++ b/docs/md/EIP20Interface.md
@@ -1,0 +1,21 @@
+# OpenST Protocol Documentation
+
+## EIP20Interface
+
+
+Interface for EIP20Token
+
+### Function Summary
+
+Signature | Returns | Details
+--- | --- | ---
+allowance<br/>(address, address) | remaining | Returns remaining allowance of _spender from _owner
+approve<br/>(address, uint256) | success | Approves _spender to transfer _value from msg.sender; emits Approval event
+balanceOf<br/>(address) | balance | Returns balance of _owner
+decimals() | uint8 | Returns decimals
+name() | string | Returns name
+symbol() | string | Returns symbol
+totalSupply() | uint256 | Returns totalSupply
+transfer<br/>(address, uint256) | success | Transfers _value from balance of msg.sender to _to; emits Transfer event
+transferFrom<br/>(address, address, uint256) | success | Transfers _value from balance of _from to _to; emits Transfer event
+

--- a/docs/md/EIP20Token.md
+++ b/docs/md/EIP20Token.md
@@ -1,0 +1,21 @@
+# OpenST Protocol Documentation
+
+## EIP20Token
+
+
+Implements EIP20 token
+
+### Function Summary
+
+Signature | Returns | Details
+--- | --- | ---
+allowance<br/>(address, address) | remaining | Takes _owner, _spender<br/><br/>Returns remaining allowance of _spender from _owner
+approve<br/>(address, uint256) | success | Takes _spender, _value<br/><br/>Approves _spender to transfer _value from msg.sender; emits Approval event
+balanceOf<br/>(address) | balance | Takes _owner<br/><br/>Returns balance of _owner
+decimals() | uint8 | Returns decimals
+name() | string | Returns name
+symbol() | string | Returns symbol
+totalSupply() | uint256 | Returns totalSupply
+transfer<br/>(address, uint256) | success | Takes _to, _value<br/><br/>Transfers _value from balance of msg.sender to _to; emits Transfer event
+transferFrom<br/>(address, address, uint256) | success | Takes _from, _to, _value<br/><br/>Transfers _value from balance of _from to _to; emits Transfer event
+

--- a/docs/md/EIP20TokenMock.md
+++ b/docs/md/EIP20TokenMock.md
@@ -1,0 +1,24 @@
+# OpenST Protocol Documentation
+
+## EIP20TokenMock
+
+
+Implements mock totalSupply function and wraps internal functions to enable testing EIP20Token
+
+### Function Summary
+
+Signature | Returns | Details
+--- | --- | ---
+allowance<br/>(address, address) | remaining | Takes _owner, _spender<br/><br/>Returns remaining allowance of _spender from _owner
+approve<br/>(address, uint256) | success | Takes _spender, _value<br/><br/>Approves _spender to transfer _value from msg.sender; emits Approval event
+balanceOf<br/>(address) | balance | Takes _owner<br/><br/>Returns balance of _owner
+burnEIP20Public<br/>(uint256) | success bool | Public wrapper for burnEIP20Public
+claimEIP20Public<br/>(address, uint256) | success bool | Public wrapper for claimEIP20Public
+decimals() | uint8 | Returns decimals
+mintEIP20Public<br/>(uint256) | success bool | Public wrapper for mintEIP20Public
+name() | string | Returns name
+symbol() | string | Returns symbol
+totalSupply() |  | Mock totalSupply function
+transfer<br/>(address, uint256) | success | Takes _to, _value<br/><br/>Transfers _value from balance of msg.sender to _to; emits Transfer event
+transferFrom<br/>(address, address, uint256) | success | Takes _from, _to, _value<br/><br/>Transfers _value from balance of _from to _to; emits Transfer event
+

--- a/docs/md/Hasher.md
+++ b/docs/md/Hasher.md
@@ -1,0 +1,15 @@
+# OpenST Protocol Documentation
+
+## Hasher
+
+
+Protocol hash functions
+
+### Function Summary
+
+Signature | Returns | Details
+--- | --- | ---
+hashRedemptionIntent<br/>(bytes32, address, uint256, uint256, uint256) | bytes32 | Returns hash of _uuid, _account, _accountNonce, _amountUT, _escrowUnlockHeight
+hashStakingIntent<br/>(bytes32, address, uint256, address, uint256, uint256, uint256) | bytes32 | Returns hash of _uuid, _account, _accountNonce, _beneficiary, _amountST, _amountUT, _escrowUnlockHeight
+hashUuid<br/>(string, string, uint256, uint256, address, uint256) | bytes32 | Returns hash of _symbol, _name, _chainIdValue, _chainIdUtility, _openSTUtility, _conversionRate
+

--- a/docs/md/OpenSTUtility.md
+++ b/docs/md/OpenSTUtility.md
@@ -1,0 +1,32 @@
+# OpenST Protocol Documentation
+
+## OpenSTUtility
+
+
+Protocol for a utility chain
+
+### Function Summary
+
+Signature | Returns | Details
+--- | --- | ---
+checkAvailability<br/>(bytes32, bytes32, address) | bool | Takes _hashSymbol, _hashName, _requester<br/><br/>Checks whether branded token is available
+completeOwnershipTransfer() | success bool | Sets proposedOwner to owner and proposedOwner to 0; only callable by proposedOwner; emits OwnershipTransferCompleted event
+confirmStakingIntent<br/>(bytes32, address, uint256, address, uint256, uint256, uint256, bytes32) | expirationHeight | Takes _uuid, _staker, _stakerNonce, _beneficiary, _amountST, _amountUT, _stakingUnlockHeight, _stakingIntentHash<br/><br/>Confirms staking intent; emits StakingIntentConfirmed event; only callable by registrar
+hashRedemptionIntent<br/>(bytes32, address, uint256, uint256, uint256) | bytes32 | Returns hash of _uuid, _account, _accountNonce, _amountUT, _escrowUnlockHeight
+hashStakingIntent<br/>(bytes32, address, uint256, address, uint256, uint256, uint256) | bytes32 | Returns hash of _uuid, _account, _accountNonce, _beneficiary, _amountST, _amountUT, _escrowUnlockHeight
+hashUuid<br/>(string, string, uint256, uint256, address, uint256) | bytes32 | Returns hash of _symbol, _name, _chainIdValue, _chainIdUtility, _openSTUtility, _conversionRate
+initiateOwnershipTransfer<br/>(address) | success bool | Takes _proposedOwner<br/><br/>Sets proposedOwner to _proposedOwner; only callable by owner; emits OwnershipTransferInitiated event
+initiateProtocolTransfer<br/>(address, address) | success bool | Takes _token, _proposedProtocol<br/><br/>Initiates transfer to _proposedProtocol for _token; only callable by adminAddress
+processMinting<br/>(bytes32) | tokenAddress | Takes _stakingIntentHash<br/><br/>Processes corresponding mint; emits ProcessedMint event
+processRedeeming<br/>(bytes32) | tokenAddress | Takes _redemptionIntentHash<br/><br/>Processes corresponding redemption; emits ProcessedRedemption event
+proposeBrandedToken<br/>(string, string, uint256) | btUuid | Takes _symbol _name _conversionRate. Congratulations on looking under the hood and obtaining ST' to call proposeBrandedToken<br/><br/>However, OpenSTFoundation is not yet actively listening to these events because to automate it we will build a web UI where you can authenticate with your msg.sender = _requester key; until that time please drop us a line on partners(at)simpletoken.org and we can work with you to register your branded token
+redeem<br/>(bytes32, uint256, uint256) | unlockHeight, redemptionIntentHash | Takes _uuid, _amountBT, _nonce<br/><br/>Redeemer must set an allowance for the branded token with OpenSTUtility as the spender so that the branded token can be taken into escrow by OpenSTUtility; emits RedemptionIntentDeclared event. Note: for STPrime, call OpenSTUtility.redeemSTPrime as a payable function. Note: nonce must be queried from OpenSTValue contract
+redeemSTPrime<br/>(uint256) | amountSTP, unlockHeight, redemptionIntentHash | Takes _nonce<br/><br/>Redeemer must send as value the amount STP to redeem; emits RedemptionIntentDeclared event. Note: nonce must be queried from OpenSTValue contract
+registerBrandedToken<br/>(string, string, uint256, address, address, bytes32) | registeredUuid | Takes _symbol, _name, _conversionRate, _requester, _brandedToken, _checkUuid<br/><br/>Registers a branded token; emits RegisteredBrandedToken event; only callable by registrar
+registeredTokenProperties<br/>(bytes32) | token address, registrar address | 
+revertMinting<br/>(bytes32) | uuid, staker, beneficiary, amount | Takes _stakingIntentHash<br/><br/>Reverts corresponding mint; emits RevertedMint event
+revertRedemption<br/>(bytes32) | uuid, redeemer, amountUT | Takes _redemptionIntentHash<br/><br/>Reverts corresponding redemption; emits RevertedRedemption event
+revokeProtocolTransfer<br/>(address) | success bool | Takes _token<br/><br/>Revokes protocol transfer; on the very first released version v0.9.1 there is no need to completeProtocolTransfer from a previous version; only callable by adminAddress
+setAdminAddress<br/>(address) | bool | Takes _adminAddress<br/><br/>Sets adminAddress to _adminAddress and returns true; only callable by owner or adminAddress; adminAddress can also be set to 0 to 'disable' it
+setOpsAddress<br/>(address) | bool | Takes _opsAddress<br/><br/>Sets opsAddress to _opsAddress and returns true; only callable by owner or adminAddress; _opsAddress can also be set to 0 to 'disable' it
+

--- a/docs/md/OpenSTUtilityInterface.md
+++ b/docs/md/OpenSTUtilityInterface.md
@@ -1,0 +1,15 @@
+# OpenST Protocol Documentation
+
+## OpenSTUtilityInterface
+
+
+Interface for OpenSTUtility
+
+### Function Summary
+
+Signature | Returns | Details
+--- | --- | ---
+confirmStakingIntent<br/>(bytes32, address, uint256, address, uint256, uint256, uint256, bytes32) | expirationHeight | Takes _uuid _staker _stakerNonce _beneficiary _amountST _amountUT _stakingUnlockHeight _stakingIntentHash<br/><br/>Confirms staking intent; emits StakingIntentConfirmed event
+processRedeeming<br/>(bytes32) | tokenAddress | Takes _redemptionIntentHash<br/><br/>Processes corresponding redemption; emits ProcessedRedemption event
+registerBrandedToken<br/>(string, string, uint256, address, address, bytes32) | registeredUuid | Takes _symbol, _name, _conversionRate, _requester, _brandedToken, _checkUuid<br/><br/>Registers a branded token; emits RegisteredBrandedToken event
+

--- a/docs/md/OpenSTValue.md
+++ b/docs/md/OpenSTValue.md
@@ -1,0 +1,34 @@
+# OpenST Protocol Documentation
+
+## OpenSTValue
+
+
+value staking contract for OpenST 
+
+### Function Summary
+
+Signature | Returns | Details
+--- | --- | ---
+addCore<br/>(address) | success bool | Takes _core<br/><br/>Adds _core to cores by core.chainIdRemote; only callable by registrar
+blocksToWaitLong() | uint256 | Returns BLOCKS_TO_WAIT_LONG
+blocksToWaitShort() | uint256 | Returns BLOCKS_TO_WAIT_SHORT
+completeOwnershipTransfer() | success bool | Sets proposedOwner to owner and proposedOwner to 0; only callable by proposedOwner; emits OwnershipTransferCompleted event
+confirmRedemptionIntent<br/>(bytes32, address, uint256, uint256, uint256, bytes32) | amountST, expirationHeight | Takes _uuid, _redeemer, _redeemerNonce, _amountUT, _redemptionUnlockHeight, _redemptionIntentHash<br/><br/>Confirms redemption intent; emits RedemptionIntentConfirmed event; only callable by registrar
+core<br/>(uint256) | address | Takes _chainIdUtility<br/><br/>Returns core address
+getNextNonce<br/>(address) | uint256 | Takes _account<br/><br/>Returns next nonce
+hashRedemptionIntent<br/>(bytes32, address, uint256, uint256, uint256) | bytes32 | Returns hash of _uuid, _account, _accountNonce, _amountUT, _escrowUnlockHeight
+hashStakingIntent<br/>(bytes32, address, uint256, address, uint256, uint256, uint256) | bytes32 | Returns hash of _uuid, _account, _accountNonce, _beneficiary, _amountST, _amountUT, _escrowUnlockHeight
+hashUuid<br/>(string, string, uint256, uint256, address, uint256) | bytes32 | Returns hash of _symbol, _name, _chainIdValue, _chainIdUtility, _openSTUtility, _conversionRate
+initiateOwnershipTransfer<br/>(address) | success bool | Takes _proposedOwner<br/><br/>Sets proposedOwner to _proposedOwner; only callable by owner; emits OwnershipTransferInitiated event
+initiateProtocolTransfer<br/>(address, address) | success bool | Takes _simpleStake, _proposedProtocol<br/><br/>Initiates transfer to _proposedProtocol for _simpleStake; only callable by adminAddress
+processStaking<br/>(bytes32) | stakeAddress | Takes _stakingIntentHash<br/><br/>Processes corresponding stake; emits ProcessedStake event
+processUnstaking<br/>(bytes32) | stakeAddress | Takes _redemptionIntentHash<br/><br/>Processes corresponding unstake; emits ProcessedUnstake event
+registerUtilityToken<br/>(string, string, uint256, uint256, address, bytes32) | uuid | Takes _symbol, _name, _conversionRate, _chainIdUtility, _stakingAccount, _checkUuid<br/><br/>Registers a utility token; emits UtilityTokenRegistered event; only callable by registrar
+revertStaking<br/>(bytes32) | uuid, staker, amountST, staker | Takes _stakingIntentHash<br/><br/>Reverts corresponding stake; emits RevertedStake event
+revertUnstaking<br/>(bytes32) | uuid, redeemer, amountST | Takes _redemptionIntentHash<br/><br/>Reverts corresponding unstake; emits RevertedUnstake event
+revokeProtocolTransfer<br/>(address) | success bool | Takes _simpleStake<br/><br/>Revokes protocol transfer; on the very first released version v0.9.1 there is no need to completeProtocolTransfer from a previous version; only callable by adminAddress
+setAdminAddress<br/>(address) | bool | Takes _adminAddress<br/><br/>Sets adminAddress to _adminAddress and returns true; only callable by owner or adminAddress; adminAddress can also be set to 0 to 'disable' it
+setOpsAddress<br/>(address) | bool | Takes _opsAddress<br/><br/>Sets opsAddress to _opsAddress and returns true; only callable by owner or adminAddress; _opsAddress can also be set to 0 to 'disable' it
+stake<br/>(bytes32, uint256, address) | amountUT, nonce, unlockHeight, stakingIntentHash | Takes _uuid, _amountST, _beneficiary<br/><br/>In order to stake the tx.origin needs to set an allowance for the OpenSTValue contract to transfer to itself to hold during the staking process.
+utilityTokenProperties<br/>(bytes32) | symbol, name, conversionRate, decimals, chainIdUtility, simpleStake, stakingAccount | 
+

--- a/docs/md/OpenSTValueInterface.md
+++ b/docs/md/OpenSTValueInterface.md
@@ -1,0 +1,16 @@
+# OpenST Protocol Documentation
+
+## OpenSTValueInterface
+
+
+Interface for OpenSTValue
+
+### Function Summary
+
+Signature | Returns | Details
+--- | --- | ---
+addCore<br/>(address) | success bool | Takes _core<br/><br/>Adds _core to cores by core.chainIdRemote
+confirmRedemptionIntent<br/>(bytes32, address, uint256, uint256, uint256, bytes32) | amountST, expirationHeight | Takes _uuid, _redeemer, _redeemerNonce, _amountUT, _redemptionUnlockHeight, _redemptionIntentHash<br/><br/>Confirms redemption intent; emits RedemptionIntentConfirmed event
+processStaking<br/>(bytes32) | stakeAddress | Takes _stakingIntentHash<br/><br/>Processes corresponding stake; emits ProcessedStake event
+registerUtilityToken<br/>(string, string, uint256, uint256, address, bytes32) | uuid | Takes _symbol, _name, _conversionRate, _chainIdUtility, _stakingAccount, _checkUuid<br/><br/>Registers a utility token; emits UtilityTokenRegistered event
+

--- a/docs/md/OpsManaged.md
+++ b/docs/md/OpsManaged.md
@@ -1,0 +1,16 @@
+# OpenST Protocol Documentation
+
+## OpsManaged
+
+
+OpenST ownership and permission model
+
+### Function Summary
+
+Signature | Returns | Details
+--- | --- | ---
+completeOwnershipTransfer() | success bool | Sets proposedOwner to owner and proposedOwner to 0; only callable by proposedOwner; emits OwnershipTransferCompleted event
+initiateOwnershipTransfer<br/>(address) | success bool | Takes _proposedOwner<br/><br/>Sets proposedOwner to _proposedOwner; only callable by owner; emits OwnershipTransferInitiated event
+setAdminAddress<br/>(address) | bool | Takes _adminAddress<br/><br/>Sets adminAddress to _adminAddress and returns true; only callable by owner or adminAddress; adminAddress can also be set to 0 to 'disable' it
+setOpsAddress<br/>(address) | bool | Takes _opsAddress<br/><br/>Sets opsAddress to _opsAddress and returns true; only callable by owner or adminAddress; _opsAddress can also be set to 0 to 'disable' it
+

--- a/docs/md/Owned.md
+++ b/docs/md/Owned.md
@@ -1,0 +1,14 @@
+# OpenST Protocol Documentation
+
+## Owned
+
+
+Implements basic ownership with 2-step transfers
+
+### Function Summary
+
+Signature | Returns | Details
+--- | --- | ---
+completeOwnershipTransfer() | success bool | Sets proposedOwner to owner and proposedOwner to 0; only callable by proposedOwner; emits OwnershipTransferCompleted event
+initiateOwnershipTransfer<br/>(address) | success bool | Takes _proposedOwner<br/><br/>Sets proposedOwner to _proposedOwner; only callable by owner; emits OwnershipTransferInitiated event
+

--- a/docs/md/ProtocolVersioned.md
+++ b/docs/md/ProtocolVersioned.md
@@ -1,0 +1,15 @@
+# OpenST Protocol Documentation
+
+## ProtocolVersioned
+
+
+Administers protocol versioning
+
+### Function Summary
+
+Signature | Returns | Details
+--- | --- | ---
+completeProtocolTransfer() | success bool | Only after the waiting period, can proposed protocol complete the transfer; emits ProtocolTransferCompleted event; only callable by proposed protocol
+initiateProtocolTransfer<br/>(address) | success bool | Takes _proposedProtocol<br/><br/>Initiates protocol transfer; emits ProtocolTransferInitiated event; only callable by protocol
+revokeProtocolTransfer() | success bool | protocol can revoke initiated protocol transfer; emits ProtocolTransferRevoked event; only callable by protocol
+

--- a/docs/md/Registrar.md
+++ b/docs/md/Registrar.md
@@ -1,0 +1,23 @@
+# OpenST Protocol Documentation
+
+## Registrar
+
+
+Administers registrations for utility tokens
+
+### Function Summary
+
+Signature | Returns | Details
+--- | --- | ---
+addCore<br/>(address, address) | success bool | Takes _registry, _core<br/><br/>Adds _core to _registry; only callable by adminAddress or opsAddress
+completeOwnershipTransfer() | success bool | Sets proposedOwner to owner and proposedOwner to 0; only callable by proposedOwner; emits OwnershipTransferCompleted event
+confirmRedemptionIntent<br/>(address, bytes32, address, uint256, uint256, uint256, bytes32) | amountST, expirationHeight | Takes __registry, uuid, _redeemer, _redeemerNonce, _amountUT, _redemptionUnlockHeight, _redemptionIntentHash<br/><br/>Confirms redemption intent with _registry; only callable by opsAddress
+confirmStakingIntent<br/>(address, bytes32, address, uint256, address, uint256, uint256, uint256, bytes32) | expirationHeight | Takes _registry, _uuid, _staker, _stakerNonce, _beneficiary, _amountST, _amountUT, _stakingUnlockHeight, _stakingIntentHash<br/><br/>Confirms staking intent with _registry; only callable by opsAddress
+initiateOwnershipTransfer<br/>(address) | success bool | Takes _proposedOwner<br/><br/>Sets proposedOwner to _proposedOwner; only callable by owner; emits OwnershipTransferInitiated event
+processRedeeming<br/>(address, bytes32) | tokenAddress | Takes _registry, _redemptionIntentHash<br/><br/>Processes corresponding redemption with _registry; only callable by adminAddress
+processStaking<br/>(address, bytes32) | stakeAddress | Takes _registry, _stakingIntentHash<br/><br/>Processes stake with _registry; only callable by adminAddress
+registerBrandedToken<br/>(address, string, string, uint256, address, address, bytes32) | registeredUuid | Takes _registry, _symbol, _name, _conversionRate, _requester, _brandedToken, _checkUuid<br/><br/>Registers a branded token with _registry; only callable by adminAddress or opsAddress
+registerUtilityToken<br/>(address, string, string, uint256, uint256, address, bytes32) | uuid | Takes _registry, _symbol, _name, _conversionRate, _chainIdUtility, _stakingAccount, _checkUuid<br/><br/>Registers a utility token with _registry; only callable by adminAddress or opsAddress
+setAdminAddress<br/>(address) | bool | Takes _adminAddress<br/><br/>Sets adminAddress to _adminAddress and returns true; only callable by owner or adminAddress; adminAddress can also be set to 0 to 'disable' it
+setOpsAddress<br/>(address) | bool | Takes _opsAddress<br/><br/>Sets opsAddress to _opsAddress and returns true; only callable by owner or adminAddress; _opsAddress can also be set to 0 to 'disable' it
+

--- a/docs/md/STPrime.md
+++ b/docs/md/STPrime.md
@@ -1,0 +1,22 @@
+# OpenST Protocol Documentation
+
+## STPrime
+
+
+A freely tradable equivalent representation of Simple Token [ST] on Ethereum mainnet on the utility chain; STPrime functions as the base token to pay for gas consumption on the utility chain; it is not an EIP20 token, but functions as the genesis guardian of the finite amount of base tokens on the utility chain
+
+### Function Summary
+
+Signature | Returns | Details
+--- | --- | ---
+burn<br/>(address, uint256) | bool | Takes _burner, _amount<br/><br/>Burns utility tokens after having redeemed them through the protocol for the staked Simple Token; only callable by protocol
+claim<br/>(address) | success bool | Takes _beneficiary<br/><br/>Transfers full claim to beneficiary; claim can be called publicly as the beneficiary and amount are set, and this allows for reduced steps on the user experience to complete the claim automatically; for first stake of ST' the gas price by one validator has to be zero to deploy the contracts and accept the very first staking of ST for ST' and its protocol executions.
+completeProtocolTransfer() | success bool | Only after the waiting period, can proposed protocol complete the transfer; emits ProtocolTransferCompleted event; only callable by proposed protocol
+initialize() |  | On setup of the utility chain the base tokens need to be transfered in full to STPrime for the base tokens to be minted as ST'
+initiateProtocolTransfer<br/>(address) | success bool | Takes _proposedProtocol<br/><br/>Initiates protocol transfer; emits ProtocolTransferInitiated event; only callable by protocol
+mint<br/>(address, uint256) |  | Takes _beneficiary, _amount<br/><br/>Mints new Simple Token Prime into circulation and increase total supply accordingly; tokens are minted into a claim to ensure that the protocol completion does not continue into foreign contracts at _beneficiary; only callable by protocol
+revokeProtocolTransfer() | success bool | protocol can revoke initiated protocol transfer; emits ProtocolTransferRevoked event; only callable by protocol
+totalSupply() | uint256 | Get totalTokenSupply as view so that child cannot edit
+unclaimed<br/>(address) | uint256 | Takes _beneficiary<br/><br/>Returns unclaimed amount for _beneficiary
+uuid() | bytes32 | Returns uuid
+

--- a/docs/md/SimpleStake.md
+++ b/docs/md/SimpleStake.md
@@ -1,0 +1,17 @@
+# OpenST Protocol Documentation
+
+## SimpleStake
+
+
+Stakes the value of an EIP20 token on Ethereum for a utility token on the OpenST platform
+
+### Function Summary
+
+Signature | Returns | Details
+--- | --- | ---
+completeProtocolTransfer() | success bool | Only after the waiting period, can proposed protocol complete the transfer; emits ProtocolTransferCompleted event; only callable by proposed protocol
+getTotalStake() | uint256 | total stake is the balance of the staking contract; accidental transfers directly to SimpleStake bypassing the OpenST protocol will not mint new utility tokens, but will add to the total stake; (accidental) donations can not be prevented
+initiateProtocolTransfer<br/>(address) | success bool | Takes _proposedProtocol<br/><br/>Initiates protocol transfer; emits ProtocolTransferInitiated event; only callable by protocol
+releaseTo<br/>(address, uint256) | success bool | Takes _to, _amount<br/><br/>Allows the protocol to release the staked amount into provided address. The protocol MUST be a contract that sets the rules on how the stake can be released and to who. The protocol takes the role of an "owner" of the stake. Only callable by protocol. Emits ReleasedStake event.
+revokeProtocolTransfer() | success bool | protocol can revoke initiated protocol transfer; emits ProtocolTransferRevoked event; only callable by protocol
+

--- a/docs/md/UtilityTokenAbstract.md
+++ b/docs/md/UtilityTokenAbstract.md
@@ -1,0 +1,21 @@
+# OpenST Protocol Documentation
+
+## UtilityTokenAbstract
+
+
+Base utility token functionality for BrandedTokens and STPrime
+
+### Function Summary
+
+Signature | Returns | Details
+--- | --- | ---
+burn<br/>(address, uint256) | success | Takes _burner, _amount<br/><br/>Burns utility tokens after having redeemed them through the protocol for the staked Simple Token
+claim<br/>(address) | success | Takes _beneficiary<br/><br/>Transfers full claim to beneficiary
+completeProtocolTransfer() | success bool | Only after the waiting period, can proposed protocol complete the transfer; emits ProtocolTransferCompleted event; only callable by proposed protocol
+initiateProtocolTransfer<br/>(address) | success bool | Takes _proposedProtocol<br/><br/>Initiates protocol transfer; emits ProtocolTransferInitiated event; only callable by protocol
+mint<br/>(address, uint256) | success | Takes _beneficiary, _amount<br/><br/>Mints new utility tokens
+revokeProtocolTransfer() | success bool | protocol can revoke initiated protocol transfer; emits ProtocolTransferRevoked event; only callable by protocol
+totalSupply() | uint256 | Get totalTokenSupply as view so that child cannot edit
+unclaimed<br/>(address) | uint256 | Takes _beneficiary<br/><br/>Returns unclaimed amount for _beneficiary
+uuid() | bytes32 | Returns uuid
+

--- a/docs/md/UtilityTokenAbstractMock.md
+++ b/docs/md/UtilityTokenAbstractMock.md
@@ -1,0 +1,24 @@
+# OpenST Protocol Documentation
+
+## UtilityTokenAbstractMock
+
+
+Implements mock claim, mint, and burn functions and wraps internal functions to enable testing UtilityTokenAbstract
+
+### Function Summary
+
+Signature | Returns | Details
+--- | --- | ---
+burn<br/>(address, uint256) | success bool | Mock burn function
+burnInternalPublic<br/>(address, uint256) | success bool | Public wrapper for burnInternal
+claim<br/>(address) | success bool | Mock claim function
+claimInternalPublic<br/>(address) | amount | Public wrapper for claimInternal
+completeProtocolTransfer() | success bool | Only after the waiting period, can proposed protocol complete the transfer; emits ProtocolTransferCompleted event; only callable by proposed protocol
+initiateProtocolTransfer<br/>(address) | success bool | Takes _proposedProtocol<br/><br/>Initiates protocol transfer; emits ProtocolTransferInitiated event; only callable by protocol
+mint<br/>(address, uint256) | success bool | Mock mint function
+mintInternalPublic<br/>(address, uint256) | success bool | Public wrapper for mintInternal
+revokeProtocolTransfer() | success bool | protocol can revoke initiated protocol transfer; emits ProtocolTransferRevoked event; only callable by protocol
+totalSupply() | uint256 | Get totalTokenSupply as view so that child cannot edit
+unclaimed<br/>(address) | uint256 | Takes _beneficiary<br/><br/>Returns unclaimed amount for _beneficiary
+uuid() | bytes32 | Returns uuid
+

--- a/docs/md/UtilityTokenInterface.md
+++ b/docs/md/UtilityTokenInterface.md
@@ -1,0 +1,17 @@
+# OpenST Protocol Documentation
+
+## UtilityTokenInterface
+
+
+Interface for UtilityToken
+
+### Function Summary
+
+Signature | Returns | Details
+--- | --- | ---
+burn<br/>(address, uint256) | success | Takes _burner, _amount<br/><br/>Burns utility tokens after having redeemed them through the protocol for the staked Simple Token
+claim<br/>(address) | success | Takes _beneficiary<br/><br/>Transfers full claim to beneficiary
+mint<br/>(address, uint256) | success | Takes _beneficiary, _amount<br/><br/>Mints new utility tokens
+totalSupply() | supply | Get totalTokenSupply as view so that child cannot edit
+uuid() | getUuid | Get unique universal identifier for utility token
+


### PR DESCRIPTION
This adds basic JSON and MD of protocol contracts, generated using the `solc --devdoc` option. The natspec documentation that was used to generate these docs is not included in this PR, because while much of our documentation is formatted for readability, manipulations/massaging was required to make the natspec documentation readable in JSON/MD, in addition to other adjustments. So, the in-line documentation will need to be updated in a separate issue (along with the addition of the scripts used to produce these files).

Note: `devdoc` gives the parameters back in alphabetical order, not the order in which they appear in the signature, so for now it was more sensible to write the order out as part of the detail of each function rather than to display the params object as is provided by `devdoc`.