### PR TITLE
Make mints and redemptions public

### DIFF
--- a/contracts/OpenSTUtility.sol
+++ b/contracts/OpenSTUtility.sol
@@ -121,7 +121,7 @@ contract OpenSTUtility is Hasher, OpsManaged {
 	mapping(address /* (un)staker */ => uint256) nonces;
 	/// store the ongoing mints and redemptions
 	mapping(bytes32 /* stakingIntentHash */ => Mint) public mints;
-	mapping(bytes32 /* redemptionIntentHash*/ => Redemption) public redemptions;
+	mapping(bytes32 /* redemptionIntentHash */ => Redemption) public redemptions;
 
 	/*
 	 *  Modifiers

--- a/contracts/OpenSTUtility.sol
+++ b/contracts/OpenSTUtility.sol
@@ -120,8 +120,8 @@ contract OpenSTUtility is Hasher, OpsManaged {
 	/// utility chains)
 	mapping(address /* (un)staker */ => uint256) nonces;
 	/// store the ongoing mints and redemptions
-	mapping(bytes32 /* stakingIntentHash */ => Mint) mints;
-	mapping(bytes32 /* redemptionIntentHash*/ => Redemption) redemptions;
+	mapping(bytes32 /* stakingIntentHash */ => Mint) public mints;
+	mapping(bytes32 /* redemptionIntentHash*/ => Redemption) public redemptions;
 
 	/*
 	 *  Modifiers

--- a/contracts/OpenSTUtilityInterface.sol
+++ b/contracts/OpenSTUtilityInterface.sol
@@ -54,4 +54,23 @@ contract OpenSTUtilityInterface {
     	external
     	returns (
     	address tokenAddress);
+
+    function mints(
+    	bytes32 /* stakingIntentHash */)
+    	public
+    	returns (
+		bytes32, /* uuid */
+		address, /* staker */
+		address, /* beneficiary */
+		uint256, /* amount */
+		uint256 /* expirationHeight */);
+
+    function redemptions(
+    	bytes32 /* redemptionIntentHash */)
+    	public
+    	returns (
+		bytes32, /* uuid */
+		address, /* redeemer */
+		uint256, /* amountUT */
+		uint256 /* unlockHeight */);
 }


### PR DESCRIPTION
Adds `public` visibility modifier to `mints` and `redemptions` and adds matching function signatures to `OpenSTUtilityInterface`. Does not lint, to minimize conflicts with #97.

Fixes #96.