### PR TITLE
Make UUIDs iterable on utility chain

### DIFF
--- a/contracts/OpenSTUtility.sol
+++ b/contracts/OpenSTUtility.sol
@@ -44,9 +44,6 @@ contract OpenSTUtility is Hasher, OpsManaged, STPrimeConfig {
     struct RegisteredToken {
         UtilityTokenInterface token;
         address registrar;
-        string symbol;
-        string name;
-        uint256 conversionRate;
     }
 
     struct Mint {
@@ -170,10 +167,7 @@ contract OpenSTUtility is Hasher, OpsManaged, STPrimeConfig {
 
         registeredTokens[uuidSTPrime] = RegisteredToken({
             token:          UtilityTokenInterface(simpleTokenPrime),
-            registrar:      registrar,
-            symbol:         STPRIME_SYMBOL,
-            name:           STPRIME_NAME,
-            conversionRate: STPRIME_CONVERSION_RATE
+            registrar:      registrar
         });
 
         uuids.push(uuidSTPrime);
@@ -624,10 +618,7 @@ contract OpenSTUtility is Hasher, OpsManaged, STPrimeConfig {
 
         registeredTokens[registeredUuid] = RegisteredToken({
             token:          _brandedToken,
-            registrar:      registrar,
-            symbol:         _symbol,
-            name:           _name,
-            conversionRate: _conversionRate
+            registrar:      registrar
         });
 
         // register name to registrar

--- a/contracts/STPrime.sol
+++ b/contracts/STPrime.sol
@@ -72,8 +72,8 @@ contract STPrime is UtilityTokenAbstract, STPrimeConfig {
         public
         UtilityTokenAbstract(
         _uuid,
-        TOKEN_SYMBOL,
-        TOKEN_NAME,
+        STPRIME_SYMBOL,
+        STPRIME_NAME,
         _chainIdValue,
         _chainIdUtility,
         _conversionRate)

--- a/contracts/STPrimeConfig.sol
+++ b/contracts/STPrimeConfig.sol
@@ -1,3 +1,4 @@
+/* solhint-disable-next-line compiler-fixed */
 pragma solidity ^0.4.17;
 
 // Copyright 2017 OpenST Ltd.
@@ -21,12 +22,13 @@ pragma solidity ^0.4.17;
 //
 // ----------------------------------------------------------------------------
 
-
+/* solhint-disable-next-line two-lines-top-level-separator */
+/// @title STPrimeConfig
 contract STPrimeConfig {
-
-    string  public constant TOKEN_SYMBOL   = "STP";
-    string  public constant TOKEN_NAME     = "SimpleTokenPrime";
-    uint8   public constant TOKEN_DECIMALS = 18;
+    string  public constant STPRIME_SYMBOL          = "STP";
+    string  public constant STPRIME_NAME            = "SimpleTokenPrime";
+    uint256 public constant STPRIME_CONVERSION_RATE = 1;
+    uint8   public constant TOKEN_DECIMALS          = 18;
 
     uint256 public constant DECIMALSFACTOR = 10**uint256(TOKEN_DECIMALS);
     uint256 public constant TOKENS_MAX     = 800000000 * DECIMALSFACTOR;

--- a/test/OpenSTUtility.js
+++ b/test/OpenSTUtility.js
@@ -200,8 +200,11 @@ contract('OpenSTUtility', function(accounts) {
 		})
 
 		it('successfully registers', async () => {
+			assert.equal(await openSTUtility.getUuidsSize.call(), 1); // there is already 1 UUID in uuids for STPrime
 			assert.equal(await openSTUtility.registerBrandedToken.call(symbol, name, conversionRate, accounts[0], brandedToken, checkBtUuid, { from: registrar }), checkBtUuid);
             result = await openSTUtility.registerBrandedToken(symbol, name, conversionRate, accounts[0], brandedToken, checkBtUuid, { from: registrar });
+			assert.equal(await openSTUtility.getUuidsSize.call(), 2);
+			assert.equal((await openSTUtility.registeredTokens.call(checkBtUuid))[2], symbol);
             await OpenSTUtility_utils.checkRegisteredBrandedTokenEvent(result.logs[0], registrar, brandedToken, checkBtUuid, symbol, name, conversionRate, accounts[0]);            
 		})
 	})

--- a/test/OpenSTUtility.js
+++ b/test/OpenSTUtility.js
@@ -204,7 +204,7 @@ contract('OpenSTUtility', function(accounts) {
 			assert.equal(await openSTUtility.registerBrandedToken.call(symbol, name, conversionRate, accounts[0], brandedToken, checkBtUuid, { from: registrar }), checkBtUuid);
             result = await openSTUtility.registerBrandedToken(symbol, name, conversionRate, accounts[0], brandedToken, checkBtUuid, { from: registrar });
 			assert.equal(await openSTUtility.getUuidsSize.call(), 2);
-			assert.equal((await openSTUtility.registeredTokens.call(checkBtUuid))[2], symbol);
+			assert.equal((await openSTUtility.registeredTokens.call(checkBtUuid))[0], brandedToken);
             await OpenSTUtility_utils.checkRegisteredBrandedTokenEvent(result.logs[0], registrar, brandedToken, checkBtUuid, symbol, name, conversionRate, accounts[0]);            
 		})
 	})

--- a/test/STPrime_utils.js
+++ b/test/STPrime_utils.js
@@ -35,8 +35,8 @@ module.exports.deploySTPrime = async (artifacts, accounts) => {
 	const conversionRate 		= 10;
 	const genesisChainIdValue 	= 3;
 	const genesisChainIdUtility = 1410;
-	const stPrimeSymbol			= await stPrimeConfig.TOKEN_SYMBOL.call();
-	const stPrimeName			= await stPrimeConfig.TOKEN_NAME.call();
+	const stPrimeSymbol			= await stPrimeConfig.STPRIME_SYMBOL.call();
+	const stPrimeName			= await stPrimeConfig.STPRIME_NAME.call();
 	const UUID 					= await hasher.hashUuid.call(stPrimeSymbol, stPrimeName, genesisChainIdValue, genesisChainIdUtility, openSTProtocol, conversionRate);
 
 	const stPrime = await STPrime.new(UUID, genesisChainIdValue, genesisChainIdUtility, conversionRate, { from: openSTProtocol });


### PR DESCRIPTION
Makes UUIDs iterable on utility chain:
- changes `registeredTokens` mapping visibility to public
- removes `registeredTokenProperties` in favor of auto-generated getter, `registeredTokens`—platform does not appear to use `registeredTokenProperties`
- inherits from the already-imported `STPrimeConfig`, strikes certain constants from `OpenSTUtility` in favor of those from `STPrimeConfig`, and attendant changes (the platform does use the auto-generated constant getters)
- adds a public state var, `uuids`, that's a dynamic `bytes32` array
- pushes UUIDs into the `uuids` array in `registerBrandedToken` (and in the constructor of `OpenSTUtility` for `STPrime`)
- adds function, `getUuidsSize`, to return size of `uuids`

Fixes #89 