### PR TITLE
Make UUIDs iterable on value chain

### DIFF
--- a/contracts/OpenSTValue.sol
+++ b/contracts/OpenSTValue.sol
@@ -112,8 +112,9 @@ contract OpenSTValue is OpsManaged, Hasher {
     uint256 public chainIdValue;
     EIP20Interface public valueToken;
     address public registrar;
+    bytes32[] public uuids;
     mapping(uint256 /* chainIdUtility */ => CoreInterface) internal cores;
-    mapping(bytes32 /* uuid */ => UtilityToken) internal utilityTokens;
+    mapping(bytes32 /* uuid */ => UtilityToken) public utilityTokens;
     /// nonce makes the staking process atomic across the two-phased process
     /// and protects against replay attack on (un)staking proofs during the process.
     /// On the value chain nonces need to strictly increase by one; on the utility
@@ -415,34 +416,6 @@ contract OpenSTValue is OpsManaged, Hasher {
     }
 
     /*
-     *  External view functions
-     */
-    function utilityTokenProperties(
-        bytes32 _uuid)
-        external
-        view
-        returns (
-        string  symbol,
-        string  name,
-        uint256 conversionRate,
-        uint8   decimals,
-        uint256 chainIdUtility,
-        address simpleStake,
-        address stakingAccount
-        /* utility token struct */) // solhint-disable-line indent
-    {
-        UtilityToken storage utilityToken = utilityTokens[_uuid];
-        return (
-            utilityToken.symbol,
-            utilityToken.name,
-            utilityToken.conversionRate,
-            utilityToken.decimals,
-            utilityToken.chainIdUtility,
-            address(utilityToken.simpleStake),
-            utilityToken.stakingAccount);
-    }
-
-    /*
      *  Public view functions
      */
     function getNextNonce(
@@ -460,6 +433,12 @@ contract OpenSTValue is OpsManaged, Hasher {
 
     function blocksToWaitShort() public pure returns (uint256) {
         return BLOCKS_TO_WAIT_SHORT;
+    }
+
+    /// @dev Returns size of uuids
+    /// @return size
+    function getUuidsSize() public view returns (uint256) {
+        return uuids.length;
     }
 
     /*
@@ -527,6 +506,7 @@ contract OpenSTValue is OpsManaged, Hasher {
             simpleStake:    simpleStake,
             stakingAccount: _stakingAccount
         });
+        uuids.push(uuid);
 
         UtilityTokenRegistered(uuid, address(simpleStake), _symbol, _name, 
             TOKEN_DECIMALS, _conversionRate, _chainIdUtility, _stakingAccount);

--- a/test/OpenSTValue.js
+++ b/test/OpenSTValue.js
@@ -195,6 +195,7 @@ contract('OpenSTValue', function(accounts) {
 		})
 
 		it('successfully registers', async () => {
+			assert.equal(await openSTValue.getUuidsSize.call(), 0);
             assert.equal(await openSTValue.registerUtilityToken.call(symbol, name, conversionRate, chainIdRemote, 0, checkUuid, { from: registrar }), checkUuid);
             result = await openSTValue.registerUtilityToken(symbol, name, conversionRate, chainIdRemote, 0, checkUuid, { from: registrar });
 
@@ -203,6 +204,8 @@ contract('OpenSTValue', function(accounts) {
             var simpleStake = new SimpleStake(result.logs[0].args.stake);
             assert.equal(await simpleStake.uuid.call(), checkUuid);
             assert.equal(await simpleStake.eip20Token.call(), valueToken.address);
+			assert.equal(await openSTValue.getUuidsSize.call(), 1);
+			assert.equal((await openSTValue.utilityTokens.call(checkUuid))[0], symbol);
 		})
 
 		it('fails to register if already exists', async () => {

--- a/test/Protocol.js
+++ b/test/Protocol.js
@@ -127,7 +127,7 @@ contract('OpenST', function(accounts) {
 
 				stPrimeSimpleStakeContractAddress = event.stake;
 
-				Assert.notEqual((await openSTValue.utilityTokenProperties.call(uuidSTP))[5], utils.NullAddress);
+				Assert.notEqual((await openSTValue.utilityTokens.call(uuidSTP))[5], utils.NullAddress);
 			});
 
 			// Initialize Transfer to ST' Contract Address


### PR DESCRIPTION
Make UUIDs iterable on value chain:
- changes `utilityTokens` mapping visibility to public
- adds a public state var, `uuids`, that's a dynamic `bytes32` array
- removes `utilityTokenProperties ` in favor of auto-generated getter, `utilityTokens `—platform does not appear to use `utilityTokenProperties`
- pushes UUIDs into the `uuids` array in `registerUtilityToken`
- adds function, `getUuidsSize`, to return size of `uuids`

Fixes #90 