### PR TITLE
Hashlock handover: update tests for redeem/unstake, add unlockSecret to events

### DIFF
--- a/contracts/OpenSTUtility.sol
+++ b/contracts/OpenSTUtility.sol
@@ -74,14 +74,14 @@ contract OpenSTUtility is Hasher, OpsManaged {
     event StakingIntentConfirmed(bytes32 indexed _uuid, bytes32 indexed _stakingIntentHash,
     	address _staker, address _beneficiary, uint256 _amountST, uint256 _amountUT, uint256 _expirationHeight);
     event ProcessedMint(bytes32 indexed _uuid, bytes32 indexed _stakingIntentHash, address _token,
-    	address _staker, address _beneficiary, uint256 _amount);
+    	address _staker, address _beneficiary, uint256 _amount, bytes32 _unlockSecret);
 	event RevertedMint(bytes32 indexed _uuid, bytes32 indexed _stakingIntentHash, address _staker,
 		address _beneficiary, uint256 _amountUT);
 	event RedemptionIntentDeclared(bytes32 indexed _uuid, bytes32 indexed _redemptionIntentHash,
 		address _token, address _redeemer, uint256 _nonce, uint256 _amount, uint256 _unlockHeight,
 		uint256 _chainIdValue);
 	event ProcessedRedemption(bytes32 indexed _uuid, bytes32 indexed _redemptionIntentHash, address _token,
-		address _redeemer, uint256 _amount);
+		address _redeemer, uint256 _amount, bytes32 _unlockSecret);
 	event RevertedRedemption(bytes32 indexed _uuid, bytes32 indexed _redemptionIntentHash,
 		address _redeemer, uint256 _amountUT);
 
@@ -399,7 +399,7 @@ contract OpenSTUtility is Hasher, OpsManaged {
     	require(token.mint(mint.beneficiary, mint.amount));
 
 		ProcessedMint(mint.uuid, _stakingIntentHash, tokenAddress, mint.staker,
-			mint.beneficiary, mint.amount);
+			mint.beneficiary, mint.amount, _unlockSecret);
 
 		delete mints[_stakingIntentHash];
 
@@ -567,7 +567,7 @@ contract OpenSTUtility is Hasher, OpsManaged {
     	require(token.burn.value(value)(redemption.redeemer, redemption.amountUT));
 
 		ProcessedRedemption(redemption.uuid, _redemptionIntentHash, token,
-			redemption.redeemer, redemption.amountUT);
+			redemption.redeemer, redemption.amountUT, _unlockSecret);
 
 		delete redemptions[_redemptionIntentHash];
 

--- a/contracts/OpenSTValue.sol
+++ b/contracts/OpenSTValue.sol
@@ -47,13 +47,13 @@ contract OpenSTValue is OpsManaged, Hasher {
     	uint256 _amountUT, uint256 _unlockHeight, bytes32 _stakingIntentHash,
     	uint256 _chainIdUtility);
     event ProcessedStake(bytes32 indexed _uuid, bytes32 indexed _stakingIntentHash,
-    	address _stake, address _staker, uint256 _amountST, uint256 _amountUT);
+    	address _stake, address _staker, uint256 _amountST, uint256 _amountUT, bytes32 _unlockSecret);
     event RevertedStake(bytes32 indexed _uuid, bytes32 indexed _stakingIntentHash,
     	address _staker, uint256 _amountST, uint256 _amountUT);
 	event RedemptionIntentConfirmed(bytes32 indexed _uuid, bytes32 _redemptionIntentHash,
 		address _redeemer, uint256 _amountST, uint256 _amountUT, uint256 _expirationHeight);
 	event ProcessedUnstake(bytes32 indexed _uuid, bytes32 indexed _redemptionIntentHash,
-		address stake, address _redeemer, uint256 _amountST);
+		address stake, address _redeemer, uint256 _amountST, bytes32 _unlockSecret);
     event RevertedUnstake(bytes32 indexed _uuid, bytes32 indexed _redemptionIntentHash,
     	address _redeemer, uint256 _amountST);
 
@@ -240,7 +240,7 @@ contract OpenSTValue is OpsManaged, Hasher {
 		require(valueToken.transfer(stakeAddress, stake.amountST));
 
     	ProcessedStake(stake.uuid, _stakingIntentHash, stakeAddress, stake.staker,
-    		stake.amountST, stake.amountUT);
+    		stake.amountST, stake.amountUT, _unlockSecret);
 
     	delete stakes[_stakingIntentHash];
 
@@ -363,7 +363,7 @@ contract OpenSTValue is OpsManaged, Hasher {
 		require(utilityToken.simpleStake.releaseTo(unstake.redeemer, unstake.amountST));
 	
 		ProcessedUnstake(unstake.uuid, _redemptionIntentHash, stakeAddress, 
-			unstake.redeemer, unstake.amountST);
+			unstake.redeemer, unstake.amountST, _unlockSecret);
 
 		delete unstakes[_redemptionIntentHash];
 

--- a/test/OpenSTUtility.js
+++ b/test/OpenSTUtility.js
@@ -295,7 +295,7 @@ contract('OpenSTUtility', function(accounts) {
 			it('successfully mints', async () => {
 				assert.equal(await openSTUtility.processMinting.call(checkStakingIntentHash, lock.s), brandedToken);
 				result = await openSTUtility.processMinting(checkStakingIntentHash, lock.s);
-				await OpenSTUtility_utils.checkProcessedMintEvent(result.logs[0], checkBtUuid, checkStakingIntentHash, brandedToken, accounts[0], accounts[0], amountUT);
+				await OpenSTUtility_utils.checkProcessedMintEvent(result.logs[0], checkBtUuid, checkStakingIntentHash, brandedToken, accounts[0], accounts[0], amountUT, lock.s);
 			})
 
 			it('fails to re-process a processed mint', async () => {
@@ -445,7 +445,7 @@ contract('OpenSTUtility', function(accounts) {
 				var postProcessTotalSupply = await brandedTokenContract.totalSupply.call();
 				assert.equal(postProcessOpenSTUtilityBal.toNumber(), openSTUtilityBal.minus(redemptionAmount).toNumber());
 				assert.equal(postProcessTotalSupply.toNumber(), totalSupply.minus(redemptionAmount).toNumber());
-	            await OpenSTUtility_utils.checkProcessedRedemptionEvent(result.logs[0], checkBtUuid, redemptionIntentHash, brandedToken, redeemer, redemptionAmount);
+	            await OpenSTUtility_utils.checkProcessedRedemptionEvent(result.logs[0], checkBtUuid, redemptionIntentHash, brandedToken, redeemer, redemptionAmount, lockR.s);
 			})
 
 			it('fails to reprocess', async () => {
@@ -480,7 +480,7 @@ contract('OpenSTUtility', function(accounts) {
 				var postProcessTotalSupply = await stPrime.totalSupply.call();
 				assert.equal(postProcessStPrimeBal.toNumber(), stPrimeBal.minus(redemptionAmount).toNumber());
 				assert.equal(postProcessTotalSupply.toNumber(), totalSupply.minus(redemptionAmount).toNumber());
-	            await OpenSTUtility_utils.checkProcessedRedemptionEvent(result.logs[0], uuidSTPrime, redemptionIntentHash, stPrime.address, redeemer, redemptionAmount);
+	            await OpenSTUtility_utils.checkProcessedRedemptionEvent(result.logs[0], uuidSTPrime, redemptionIntentHash, stPrime.address, redeemer, redemptionAmount, lockR.s);
 			})
 		})
 	})
@@ -524,7 +524,7 @@ contract('OpenSTUtility', function(accounts) {
 				var postProcessTotalSupply = await brandedTokenContract.totalSupply.call();
 				assert.equal(postProcessOpenSTUtilityBal.toNumber(), openSTUtilityBal.minus(redemptionAmount).toNumber());
 				assert.equal(postProcessTotalSupply.toNumber(), totalSupply.minus(redemptionAmount).toNumber());
-	            await OpenSTUtility_utils.checkProcessedRedemptionEvent(result.logs[0], checkBtUuid, redemptionIntentHash, brandedToken, redeemer, redemptionAmount);
+	            await OpenSTUtility_utils.checkProcessedRedemptionEvent(result.logs[0], checkBtUuid, redemptionIntentHash, brandedToken, redeemer, redemptionAmount, lockR.s);
 			})
 		})
 
@@ -557,7 +557,7 @@ contract('OpenSTUtility', function(accounts) {
 				var postProcessTotalSupply = await stPrime.totalSupply.call();
 				assert.equal(postProcessStPrimeBal.toNumber(), stPrimeBal.minus(redemptionAmount).toNumber());
 				assert.equal(postProcessTotalSupply.toNumber(), totalSupply.minus(redemptionAmount).toNumber());
-	            await OpenSTUtility_utils.checkProcessedRedemptionEvent(result.logs[0], uuidSTPrime, redemptionIntentHash, stPrime.address, redeemer, redemptionAmount);
+	            await OpenSTUtility_utils.checkProcessedRedemptionEvent(result.logs[0], uuidSTPrime, redemptionIntentHash, stPrime.address, redeemer, redemptionAmount, lockR.s);
 			})
 		})
 	});

--- a/test/OpenSTUtility.js
+++ b/test/OpenSTUtility.js
@@ -82,7 +82,6 @@ const BigNumber = require('bignumber.js');
 /// ProcessRedeeming
 ///		BrandedToken
 /// 		fails to process if redemptionIntentHash is empty
-/// 		fails to process if msg.sender is not redeemer or registrar
 /// 		successfully processes
 /// 		fails to reprocess
 ///		STPrime
@@ -112,6 +111,7 @@ contract('OpenSTUtility', function(accounts) {
 	const requester  			= "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 	const token 	 			= "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
 	const redeemer 				= accounts[0];
+	const notRedeemer			= accounts[5];
 
 	var result 					= null;
 	var checkBtUuid 			= null;
@@ -310,7 +310,6 @@ contract('OpenSTUtility', function(accounts) {
 		const redeemAmountUT = new BigNumber(web3.toWei(1, "ether"));
 
 		const lock = HashLock.getHashLock();
-		// TODO: protocol#94 use lockR to redeem in unit tests.
 		const lockR = HashLock.getHashLock();
 
 		before(async () => {
@@ -330,35 +329,35 @@ contract('OpenSTUtility', function(accounts) {
 	    })
 
 		it('fails to redeem when uuid is empty', async () => {
-            await Utils.expectThrow(openSTUtility.redeem("", redeemAmountUT, 2, { from: redeemer }));
+            await Utils.expectThrow(openSTUtility.redeem("", redeemAmountUT, 2, lockR.l, { from: redeemer }));
 		})
 
 		it('fails to redeem when amount is not > 0', async () => {
-            await Utils.expectThrow(openSTUtility.redeem(checkBtUuid, 0, 2, { from: redeemer }));
+            await Utils.expectThrow(openSTUtility.redeem(checkBtUuid, 0, 2, lockR.l, { from: redeemer }));
 		})
 
 		it('fails to redeem when nonce is not >= previously', async () => {
-            await Utils.expectThrow(openSTUtility.redeem(checkBtUuid, redeemAmountUT, 0, { from: redeemer }));
+            await Utils.expectThrow(openSTUtility.redeem(checkBtUuid, redeemAmountUT, 0, lockR.l, { from: redeemer }));
 		})
 
 		it('fails to redeem when uuid is uuidSTPrime', async () => {
 			uuidSTPrime = await openSTUtility.uuidSTPrime.call();
-            await Utils.expectThrow(openSTUtility.redeem(uuidSTPrime, redeemAmountUT, 2, { from: redeemer }));
+            await Utils.expectThrow(openSTUtility.redeem(uuidSTPrime, redeemAmountUT, 2, lockR.l, { from: redeemer }));
 		})
 
 		it('fails to redeem if not approved to transfer the amount', async () => {
 			await brandedTokenContract.approve(openSTUtility.address, 0, { from: redeemer });
-            await Utils.expectThrow(openSTUtility.redeem(checkBtUuid, redeemAmountUT, 2, { from: redeemer }));
+            await Utils.expectThrow(openSTUtility.redeem(checkBtUuid, redeemAmountUT, 2, lockR.l, { from: redeemer }));
 			await brandedTokenContract.approve(openSTUtility.address, redeemAmountUT, { from: redeemer });
 		})
 
 		it('successfully redeems', async () => {
-			var redeemReturns = await openSTUtility.redeem.call(checkBtUuid, redeemAmountUT, 2, { from: redeemer });
+			var redeemReturns = await openSTUtility.redeem.call(checkBtUuid, redeemAmountUT, 2, lockR.l, { from: redeemer });
 
             // call block number is one less than send block number
             unlockHeight = redeemReturns[0].plus(1);
-            var checkRedemptionIntentHash = await openSTUtility.hashRedemptionIntent.call(checkBtUuid, accounts[0], 2, redeemAmountUT, unlockHeight);
-            result = await openSTUtility.redeem(checkBtUuid, redeemAmountUT, 2, { from: redeemer });
+            var checkRedemptionIntentHash = await openSTUtility.hashRedemptionIntent.call(checkBtUuid, accounts[0], 2, redeemAmountUT, unlockHeight, lockR.l);
+            result = await openSTUtility.redeem(checkBtUuid, redeemAmountUT, 2, lockR.l, { from: redeemer });
 
             await OpenSTUtility_utils.checkRedemptionIntentDeclaredEvent(result.logs[0], checkBtUuid, checkRedemptionIntentHash, brandedToken,
 			redeemer, 2, redeemAmountUT, unlockHeight, chainIdValue);
@@ -369,6 +368,7 @@ contract('OpenSTUtility', function(accounts) {
 
 		const redeemSTP = new BigNumber(2);
 		const lock = HashLock.getHashLock();
+		const lockR = HashLock.getHashLock();
 
 		before(async () => {
 	        contracts  		 		= await OpenSTUtility_utils.deployOpenSTUtility(artifacts, accounts);
@@ -383,20 +383,20 @@ contract('OpenSTUtility', function(accounts) {
 	    })
 
 		it('fails to redeem when msg.value is not > 0', async () => {
-            await Utils.expectThrow(openSTUtility.redeemSTPrime(redeemSTP.toNumber(), { from: redeemer, value: 0 }));
+            await Utils.expectThrow(openSTUtility.redeemSTPrime(redeemSTP.toNumber(), lockR.l, { from: redeemer, value: 0 }));
 		})
 
 		it('fails to redeem when nonce is not >= previously', async () => {
-            await Utils.expectThrow(openSTUtility.redeemSTPrime(0, { from: redeemer, value: 2 }));
+            await Utils.expectThrow(openSTUtility.redeemSTPrime(0, lockR.l, { from: redeemer, value: 2 }));
 		})
 
 		it('successfully redeems', async () => {
-			var redeemReturns = await openSTUtility.redeemSTPrime.call(redeemSTP.toNumber(), { from: redeemer, value: 2 });
+			var redeemReturns = await openSTUtility.redeemSTPrime.call(redeemSTP.toNumber(), lockR.l, { from: redeemer, value: 2 });
 
 			// call block number is one less than send block number
 			unlockHeight = redeemReturns[1].plus(1)
-			var checkRedemptionIntentHash = await openSTUtility.hashRedemptionIntent.call(uuidSTPrime, redeemer, 2, redeemSTP, unlockHeight);
-			result = await openSTUtility.redeemSTPrime(redeemSTP, { from: redeemer, value: redeemSTP });
+			var checkRedemptionIntentHash = await openSTUtility.hashRedemptionIntent.call(uuidSTPrime, redeemer, 2, redeemSTP, unlockHeight, lockR.l);
+			result = await openSTUtility.redeemSTPrime(redeemSTP, lockR.l, { from: redeemer, value: redeemSTP });
 
 			await OpenSTUtility_utils.checkRedemptionIntentDeclaredEvent(result.logs[0], uuidSTPrime, checkRedemptionIntentHash, stPrime.address,
 				redeemer, 2, redeemSTP.toNumber(), unlockHeight, chainIdValue);
@@ -409,6 +409,7 @@ contract('OpenSTUtility', function(accounts) {
 		var brandedTokenContract = null;
 
 		const lock = HashLock.getHashLock();
+		const lockR = HashLock.getHashLock();
 
 		context('BrandedToken', async () => {
 			var redemptionAmount = 3;
@@ -426,23 +427,19 @@ contract('OpenSTUtility', function(accounts) {
 				brandedTokenContract = new BrandedToken(brandedToken);
 				await brandedTokenContract.claim(accounts[0]);
 				await brandedTokenContract.approve(openSTUtility.address, redemptionAmount, { from: redeemer });
-	            result = await openSTUtility.redeem(checkBtUuid, redemptionAmount, 2, { from: redeemer });
+	            result = await openSTUtility.redeem(checkBtUuid, redemptionAmount, 2, lockR.l, { from: redeemer });
 	            redemptionIntentHash = result.logs[0].args._redemptionIntentHash;
 		    })
 
 			it('fails to process if redemptionIntentHash is empty', async () => {
-	            await Utils.expectThrow(openSTUtility.processRedeeming("", { from: redeemer }));
-			})
-
-			it('fails to process if msg.sender is not redeemer or registrar', async () => {
-	            await Utils.expectThrow(openSTUtility.processRedeeming(redemptionIntentHash, { from: accounts[5] }));
+	            await Utils.expectThrow(openSTUtility.processRedeeming("", lockR.s, { from: notRedeemer }));
 			})
 
 			it('successfully processes', async () => {
 				var openSTUtilityBal = await brandedTokenContract.balanceOf.call(openSTUtility.address);
 				var totalSupply = await brandedTokenContract.totalSupply.call();
-				assert.equal(await openSTUtility.processRedeeming.call(redemptionIntentHash, { from: redeemer }), brandedToken);
-				result = await openSTUtility.processRedeeming(redemptionIntentHash, { from: redeemer });
+				assert.equal(await openSTUtility.processRedeeming.call(redemptionIntentHash, lockR.s, { from: notRedeemer }), brandedToken);
+				result = await openSTUtility.processRedeeming(redemptionIntentHash, lockR.s, { from: notRedeemer });
 
 				var postProcessOpenSTUtilityBal = await brandedTokenContract.balanceOf.call(openSTUtility.address);
 				var postProcessTotalSupply = await brandedTokenContract.totalSupply.call();
@@ -452,7 +449,7 @@ contract('OpenSTUtility', function(accounts) {
 			})
 
 			it('fails to reprocess', async () => {
-	            await Utils.expectThrow(openSTUtility.processRedeeming(redemptionIntentHash, { from: redeemer }));
+	            await Utils.expectThrow(openSTUtility.processRedeeming(redemptionIntentHash, lockR.s, { from: notRedeemer }));
 			})
 		})
 
@@ -469,15 +466,15 @@ contract('OpenSTUtility', function(accounts) {
 				await openSTUtility.confirmStakingIntent(uuidSTPrime, accounts[0], 1, accounts[0], amountST, amountUT, 80668, lock.l, checkStakingIntentHash, { from: registrar });
 				await openSTUtility.processMinting(checkStakingIntentHash, lock.s);
 				await stPrime.claim(accounts[0]);
-				result = await openSTUtility.redeemSTPrime(redemptionAmount, { from: redeemer, value: redemptionAmount });
+				result = await openSTUtility.redeemSTPrime(redemptionAmount, lockR.l, { from: redeemer, value: redemptionAmount });
 				redemptionIntentHash = result.logs[0].args._redemptionIntentHash;
 		    })
 
 			it('successfully processes', async () => {
 				var stPrimeBal = await web3.eth.getBalance(stPrime.address);
 				var totalSupply = await stPrime.totalSupply.call();
-				assert.equal(await openSTUtility.processRedeeming.call(redemptionIntentHash, { from: redeemer }), stPrime.address);
-				result = await openSTUtility.processRedeeming(redemptionIntentHash, { from: redeemer });
+				assert.equal(await openSTUtility.processRedeeming.call(redemptionIntentHash, lockR.s, { from: notRedeemer }), stPrime.address);
+				result = await openSTUtility.processRedeeming(redemptionIntentHash, lockR.s, { from: notRedeemer });
 
 				var postProcessStPrimeBal = await web3.eth.getBalance(stPrime.address);
 				var postProcessTotalSupply = await stPrime.totalSupply.call();
@@ -494,6 +491,7 @@ contract('OpenSTUtility', function(accounts) {
 		var brandedTokenContract = null;
 
 		const lock = HashLock.getHashLock();
+		const lockR = HashLock.getHashLock();
 
 		context('BrandedToken', async () => {
 			var redemptionAmount = 3;
@@ -511,16 +509,16 @@ contract('OpenSTUtility', function(accounts) {
 				brandedTokenContract = new BrandedToken(brandedToken);
 				await brandedTokenContract.claim(accounts[0]);
 				await brandedTokenContract.approve(openSTUtility.address, redemptionAmount, { from: redeemer });
-	            result = await openSTUtility.redeem(checkBtUuid, redemptionAmount, 2, { from: redeemer });
+	            result = await openSTUtility.redeem(checkBtUuid, redemptionAmount, 2, lockR.l, { from: redeemer });
 	            redemptionIntentHash = result.logs[0].args._redemptionIntentHash;
 		    })
 
 			it('successfully processes by registrar', async () => {
 				var openSTUtilityBal = await brandedTokenContract.balanceOf.call(openSTUtility.address);
 				var totalSupply = await brandedTokenContract.totalSupply.call();
-				assert.equal(await openSTUtility.processRedeeming.call(redemptionIntentHash, { from: redeemer }), brandedToken);
+				assert.equal(await openSTUtility.processRedeeming.call(redemptionIntentHash, lockR.s, { from: notRedeemer }), brandedToken);
 				// redemption is processed by Registrar
-				result = await openSTUtility.processRedeeming(redemptionIntentHash, { from: registrar });
+				result = await openSTUtility.processRedeeming(redemptionIntentHash, lockR.s, { from: registrar });
 
 				var postProcessOpenSTUtilityBal = await brandedTokenContract.balanceOf.call(openSTUtility.address);
 				var postProcessTotalSupply = await brandedTokenContract.totalSupply.call();
@@ -544,16 +542,16 @@ contract('OpenSTUtility', function(accounts) {
 	            await openSTUtility.confirmStakingIntent(uuidSTPrime, accounts[0], 1, accounts[0], amountST, amountUT, 80668, lock.l, checkStakingIntentHash, { from: registrar });
 	            await openSTUtility.processMinting(checkStakingIntentHash, lock.s);
 				await stPrime.claim(accounts[0]);
-	            result = await openSTUtility.redeemSTPrime(redemptionAmount, { from: redeemer, value: redemptionAmount });
+	            result = await openSTUtility.redeemSTPrime(redemptionAmount, lockR.l, { from: redeemer, value: redemptionAmount });
 	            redemptionIntentHash = result.logs[0].args._redemptionIntentHash;
 		    })
 
 			it('successfully processes by registrar', async () => {
 				var stPrimeBal = await web3.eth.getBalance(stPrime.address);
 				var totalSupply = await stPrime.totalSupply.call();
-				assert.equal(await openSTUtility.processRedeeming.call(redemptionIntentHash, { from: redeemer }), stPrime.address);
+				assert.equal(await openSTUtility.processRedeeming.call(redemptionIntentHash, lockR.s, { from: notRedeemer }), stPrime.address);
 				// redemption is processed by Registrar
-				result = await openSTUtility.processRedeeming(redemptionIntentHash, { from: registrar });
+				result = await openSTUtility.processRedeeming(redemptionIntentHash, lockR.s, { from: registrar });
 
 				var postProcessStPrimeBal = await web3.eth.getBalance(stPrime.address);
 				var postProcessTotalSupply = await stPrime.totalSupply.call();
@@ -562,12 +560,13 @@ contract('OpenSTUtility', function(accounts) {
 	            await OpenSTUtility_utils.checkProcessedRedemptionEvent(result.logs[0], uuidSTPrime, redemptionIntentHash, stPrime.address, redeemer, redemptionAmount);
 			})
 		})
-
+	});
 
 	// Unit test cases for revert redemption
 	describe('revert redemption', async () => {
 
 		const lock = HashLock.getHashLock();
+		const lockR = HashLock.getHashLock();
 
 		context('revert redemption', async () => {
 
@@ -597,7 +596,7 @@ contract('OpenSTUtility', function(accounts) {
 				// redeemerForRevert is approved with 5 BT
 				await brandedTokenContract.approve(OpenSTUtility.address, redemptionAmountBT, { from: redeemerForRevert });
 				// After calling Redeem is left with 3 BT since redemptionAmountBT is 2 (5-2)
-				result = await OpenSTUtility.redeem(checkBtUuid, redemptionAmountBT, 2, { from: redeemerForRevert });
+				result = await OpenSTUtility.redeem(checkBtUuid, redemptionAmountBT, 2, lockR.l, { from: redeemerForRevert });
 				redemptionIntentHash = result.logs[0].args._redemptionIntentHash;
 			});
 
@@ -648,7 +647,7 @@ contract('OpenSTUtility', function(accounts) {
 
 			it('fails to processRedeeming after revert redemption', async () => {
 
-				await Utils.expectThrow(openSTUtility.processRedeeming(redemptionIntentHash, { from: redeemerForRevert }));
+				await Utils.expectThrow(openSTUtility.processRedeeming(redemptionIntentHash, lockR.l, { from: redeemerForRevert }));
 
 			});
 
@@ -700,7 +699,5 @@ contract('OpenSTUtility', function(accounts) {
 					accounts[0], AMOUNT_BT);
 			})
 		})
-	});
-	// where does this brace open?
 	});
 });

--- a/test/OpenSTUtility.js
+++ b/test/OpenSTUtility.js
@@ -60,8 +60,8 @@ const BigNumber = require('bignumber.js');
 ///
 /// ProcessMinting
 /// 	when expirationHeight is > block number
-///			fails if stakingIntentHash is empty
-///			fails if msg.sender != staker
+///			fails to process if stakingIntentHash is empty
+///			fails to process if hash of unlockSecret does not match hashlock
 ///			successfully mints
 /// 		fails to re-process a processed mint
 ///		when expirationHeight is < block number // TBD: how or where to test this practically
@@ -82,6 +82,7 @@ const BigNumber = require('bignumber.js');
 /// ProcessRedeeming
 ///		BrandedToken
 /// 		fails to process if redemptionIntentHash is empty
+/// 		fails to process if hash of unlockSecret does not match hashlock
 /// 		successfully processes
 /// 		fails to reprocess
 ///		STPrime
@@ -283,11 +284,11 @@ contract('OpenSTUtility', function(accounts) {
 	            result = await openSTUtility.confirmStakingIntent(checkBtUuid, accounts[0], 1, accounts[0], amountST, amountUT, 80668, lock.l, checkStakingIntentHash, { from: registrar });
 		    })
 
-			it('fails if stakingIntentHash is empty', async () => {
+			it('fails to process if stakingIntentHash is empty', async () => {
 	            await Utils.expectThrow(openSTUtility.processMinting("", lock.s));
 			})
 
-			it('fails when presented with a wrong secret', async () => {
+			it('fails to process if hash of unlockSecret does not match hashlock', async () => {
 				const differentLock = HashLock.getHashLock();
 	            await Utils.expectThrow(openSTUtility.processMinting(checkStakingIntentHash, differentLock.s, { from: accounts[1] }));
 			})
@@ -433,6 +434,10 @@ contract('OpenSTUtility', function(accounts) {
 
 			it('fails to process if redemptionIntentHash is empty', async () => {
 	            await Utils.expectThrow(openSTUtility.processRedeeming("", lockR.s, { from: notRedeemer }));
+			})
+
+			it('fails to process if hash of unlockSecret does not match hashlock', async () => {
+	            await Utils.expectThrow(openSTUtility.processRedeeming(redemptionIntentHash, "incorrect unlock secret", { from: notRedeemer }));
 			})
 
 			it('successfully processes', async () => {

--- a/test/OpenSTUtility_utils.js
+++ b/test/OpenSTUtility_utils.js
@@ -150,7 +150,7 @@ module.exports.checkStakingIntentConfirmedEventOnProtocol = (formattedDecodedEve
   assert.equal(event._amountUT, _amountUT.toNumber());
 }
 
-module.exports.checkProcessedMintEvent = (event, _uuid, _stakingIntentHash, _token, _staker, _beneficiary, _amount) => {
+module.exports.checkProcessedMintEvent = (event, _uuid, _stakingIntentHash, _token, _staker, _beneficiary, _amount, _unlockSecret) => {
 	if (Number.isInteger(_amount)) {
 		_amount = new BigNumber(_amount);
 	}
@@ -162,6 +162,7 @@ module.exports.checkProcessedMintEvent = (event, _uuid, _stakingIntentHash, _tok
 	assert.equal(event.args._staker, _staker);
 	assert.equal(event.args._beneficiary, _beneficiary);
 	assert.equal(event.args._amount.toNumber(), _amount.toNumber());
+	assert.equal(event.args._unlockSecret, _unlockSecret);
 }
 
 module.exports.checkRedemptionIntentDeclaredEvent = (event, _uuid, _redemptionIntentHash, _token, _redeemer, _nonce, _amount, _unlockHeight, _chainIdValue) => {
@@ -192,7 +193,7 @@ module.exports.checkRedemptionIntentDeclaredEvent = (event, _uuid, _redemptionIn
 	assert.equal(event.args._chainIdValue.toNumber(), _chainIdValue.toNumber());
 }
 
-module.exports.checkProcessedRedemptionEvent = (event, _uuid, _redemptionIntentHash, _token, _redeemer, _amount) => {
+module.exports.checkProcessedRedemptionEvent = (event, _uuid, _redemptionIntentHash, _token, _redeemer, _amount, _unlockSecret) => {
 	if (Number.isInteger(_amount)) {
 		_amount = new BigNumber(_amount);
 	}
@@ -203,6 +204,7 @@ module.exports.checkProcessedRedemptionEvent = (event, _uuid, _redemptionIntentH
 	assert.equal(event.args._token, _token);
 	assert.equal(event.args._redeemer, _redeemer);
 	assert.equal(event.args._amount.toNumber(), _amount.toNumber());
+	assert.equal(event.args._unlockSecret, _unlockSecret);
 }
 
 module.exports.checkRevertedMintEvent = (event, _uuid, _stakingIntentHash, _staker, _beneficiary, _amount) => {

--- a/test/OpenSTValue.js
+++ b/test/OpenSTValue.js
@@ -329,7 +329,7 @@ contract('OpenSTValue', function(accounts) {
 			stakeBal = await valueToken.balanceOf.call(stake);
 			assert.equal(openSTValueBal.toNumber(), 0);
 			assert.equal(stakeBal.toNumber(), amountST);
-      		await OpenSTValue_utils.checkProcessedStakeEvent(result.logs[0], checkUuid, stakingIntentHash, stake, accounts[0], amountST, amountUT);
+      		await OpenSTValue_utils.checkProcessedStakeEvent(result.logs[0], checkUuid, stakingIntentHash, stake, accounts[0], amountST, amountUT, lock.s);
 		})
 
 		it('fails to reprocess', async () => {
@@ -483,7 +483,7 @@ contract('OpenSTValue', function(accounts) {
 				redeemerBal = await valueToken.balanceOf.call(redeemer);
 				assert.equal(stakeBal.toNumber(), 0);
 				assert.equal(redeemerBal.toNumber(), 1);
-	            await OpenSTValue_utils.checkProcessedUnstakeEvent(result.logs[0], checkUuid, redemptionIntentHash, stake, redeemer, 1);
+	            await OpenSTValue_utils.checkProcessedUnstakeEvent(result.logs[0], checkUuid, redemptionIntentHash, stake, redeemer, 1, lockR.s);
 			})
 
 			it('fails to reprocess', async () => {
@@ -723,7 +723,7 @@ contract('OpenSTValue', function(accounts) {
 
 				// Successfull ProcessUnstaking				
 				processUnstakingResult = await openSTValue.processUnstaking(redemptionIntentHash, lockR.s, { from: notRedeemer });
-				await OpenSTValue_utils.checkProcessedUnstakeEvent(processUnstakingResult.logs[0], checkUuid, redemptionIntentHash, stake, redeemer, amountST);
+				await OpenSTValue_utils.checkProcessedUnstakeEvent(processUnstakingResult.logs[0], checkUuid, redemptionIntentHash, stake, redeemer, amountST, lockR.s);
 
 			});
 			

--- a/test/OpenSTValue.js
+++ b/test/OpenSTValue.js
@@ -65,7 +65,7 @@ const BigNumber = require('bignumber.js');
 ///
 /// ProcessStaking
 ///		fails to process when stakingIntentHash is empty
-///		fails to process when presented with wrong secret
+///		fails to process if hash of unlockSecret does not match hashlock
 ///		successfully processes
 ///		fails to reprocess
 ///
@@ -85,6 +85,7 @@ const BigNumber = require('bignumber.js');
 /// ProcessUnstaking
 /// 	when expirationHeight is > block number
 /// 		fails to process when redemptionIntentHash is empty
+/// 		fails to process if hash of unlockSecret does not match hashlock
 /// 		fails to process when utility token does not have a simpleStake address
 ///			successfully processes
 ///			fails to reprocess
@@ -312,7 +313,7 @@ contract('OpenSTValue', function(accounts) {
             await Utils.expectThrow(openSTValue.processStaking("", lock.s, { from: accounts[0] }));
 		})
 
-		it('fails to process when presented with wrong secret', async () => {
+		it('fails to process if hash of unlockSecret does not match hashlock', async () => {
 			const differentLock = HashLock.getHashLock();
 			// registrar can additionally as a fallback process staking in v0.9
             await Utils.expectThrow(openSTValue.processStaking(stakingIntentHash, differentLock.s, { from: accounts[5] }));
@@ -466,6 +467,10 @@ contract('OpenSTValue', function(accounts) {
 
 			it('fails to process when redemptionIntentHash is empty', async () => {
 	            await Utils.expectThrow(openSTValue.processUnstaking("", lockR.s, { from: notRedeemer }));
+			})
+
+			it('fails to process if hash of unlockSecret does not match hashlock', async () => {
+	            await Utils.expectThrow(openSTValue.processUnstaking(redemptionIntentHash, "incorrect unlock secret", { from: notRedeemer }));
 			})
 
 			it('fails to process when utility token does not have a simpleStake address', async () => {

--- a/test/OpenSTValue.js
+++ b/test/OpenSTValue.js
@@ -85,7 +85,6 @@ const BigNumber = require('bignumber.js');
 /// ProcessUnstaking
 /// 	when expirationHeight is > block number
 /// 		fails to process when redemptionIntentHash is empty
-/// 		fails to process when redeemer is not msg.sender
 /// 		fails to process when utility token does not have a simpleStake address
 ///			successfully processes
 ///			fails to reprocess
@@ -346,6 +345,7 @@ contract('OpenSTValue', function(accounts) {
 		var amountUT 				= conversionRate;
 
 		const lock = HashLock.getHashLock();
+		const lockR = HashLock.getHashLock();
 
 		before(async () => {
 			contracts   = await OpenSTValue_utils.deployOpenSTValue(artifacts, accounts);
@@ -360,45 +360,45 @@ contract('OpenSTValue', function(accounts) {
 		})
 
 		it('fails to confirm by non-registrar', async () => {
-			redemptionIntentHash = await openSTValue.hashRedemptionIntent.call(checkUuid, redeemer, nonce, amountUT, redemptionUnlockHeight);
-            await Utils.expectThrow(openSTValue.confirmRedemptionIntent(checkUuid, redeemer, nonce, amountUT, redemptionUnlockHeight, redemptionIntentHash, { from: accounts[0] }));
+			redemptionIntentHash = await openSTValue.hashRedemptionIntent.call(checkUuid, redeemer, nonce, amountUT, redemptionUnlockHeight, lockR.l);
+            await Utils.expectThrow(openSTValue.confirmRedemptionIntent(checkUuid, redeemer, nonce, amountUT, redemptionUnlockHeight, lockR.l, redemptionIntentHash, { from: accounts[0] }));
 		})
 
 		it('fails to confirm when utility token does not have a simpleStake address', async () => {
 			// Recalculate hash to confirm that it is not the error
-			redemptionIntentHash = await openSTValue.hashRedemptionIntent.call("bad UUID", redeemer, nonce, amountUT, redemptionUnlockHeight);
-            await Utils.expectThrow(openSTValue.confirmRedemptionIntent("bad UUID", redeemer, nonce, amountUT, redemptionUnlockHeight, redemptionIntentHash, { from: registrar }));
+			redemptionIntentHash = await openSTValue.hashRedemptionIntent.call("bad UUID", redeemer, nonce, amountUT, redemptionUnlockHeight, lockR.l);
+            await Utils.expectThrow(openSTValue.confirmRedemptionIntent("bad UUID", redeemer, nonce, amountUT, redemptionUnlockHeight, lockR.l, redemptionIntentHash, { from: registrar }));
 		})
 
 		it('fails to confirm when amountUT is not > 0', async () => {
 			// Recalculate hash to confirm that it is not the error
-			redemptionIntentHash = await openSTValue.hashRedemptionIntent.call(checkUuid, redeemer, nonce, 0, redemptionUnlockHeight);
-            await Utils.expectThrow(openSTValue.confirmRedemptionIntent(checkUuid, redeemer, nonce, 0, redemptionUnlockHeight, redemptionIntentHash, { from: registrar }));
+			redemptionIntentHash = await openSTValue.hashRedemptionIntent.call(checkUuid, redeemer, nonce, 0, redemptionUnlockHeight, lockR.l);
+            await Utils.expectThrow(openSTValue.confirmRedemptionIntent(checkUuid, redeemer, nonce, 0, redemptionUnlockHeight, lockR.l, redemptionIntentHash, { from: registrar }));
 		})
 
 		it('fails to confirm when redemptionUnlockHeight is not > 0', async () => {
 			// Recalculate hash to confirm that it is not the error
-			redemptionIntentHash = await openSTValue.hashRedemptionIntent.call(checkUuid, redeemer, nonce, amountUT, 0);
-            await Utils.expectThrow(openSTValue.confirmRedemptionIntent(checkUuid, redeemer, nonce, amountUT, 0, redemptionIntentHash, { from: registrar }));
+			redemptionIntentHash = await openSTValue.hashRedemptionIntent.call(checkUuid, redeemer, nonce, amountUT, 0, lockR.l);
+            await Utils.expectThrow(openSTValue.confirmRedemptionIntent(checkUuid, redeemer, nonce, amountUT, 0, lockR.l, redemptionIntentHash, { from: registrar }));
 		})
 
 		it('fails to confirm when redemptionIntentHash is empty', async () => {
-            await Utils.expectThrow(openSTValue.confirmRedemptionIntent(checkUuid, redeemer, nonce, amountUT, redemptionUnlockHeight, "", { from: registrar }));
+            await Utils.expectThrow(openSTValue.confirmRedemptionIntent(checkUuid, redeemer, nonce, amountUT, redemptionUnlockHeight, lockR.l, "", { from: registrar }));
 		})
 
 		it('fails to confirm when nonce is not exactly 1 greater than previously', async () => {
 			// Recalculate hash to confirm that it is not the error
-			redemptionIntentHash = await openSTValue.hashRedemptionIntent.call(checkUuid, redeemer, nonce.minus(1), amountUT, redemptionUnlockHeight);
-            await Utils.expectThrow(openSTValue.confirmRedemptionIntent(checkUuid, redeemer, nonce.minus(1), amountUT, redemptionUnlockHeight, redemptionIntentHash, { from: registrar }));
+			redemptionIntentHash = await openSTValue.hashRedemptionIntent.call(checkUuid, redeemer, nonce.minus(1), amountUT, redemptionUnlockHeight, lockR.l);
+            await Utils.expectThrow(openSTValue.confirmRedemptionIntent(checkUuid, redeemer, nonce.minus(1), amountUT, redemptionUnlockHeight, lockR.l, redemptionIntentHash, { from: registrar }));
 		})
 
 		it('fails to confirm when redemptionIntentHash does not match calculated hash', async () => {
-            await Utils.expectThrow(openSTValue.confirmRedemptionIntent(checkUuid, redeemer, nonce.minus(1), amountUT, redemptionUnlockHeight, "bad hash", { from: registrar }));
+            await Utils.expectThrow(openSTValue.confirmRedemptionIntent(checkUuid, redeemer, nonce.minus(1), amountUT, redemptionUnlockHeight, lockR.l, "bad hash", { from: registrar }));
 		})
 
 		it('fails to confirm when token balance of stake is not >= amountST', async () => {
-			redemptionIntentHash = await openSTValue.hashRedemptionIntent.call(checkUuid, redeemer, nonce, amountUT, redemptionUnlockHeight);
-            await Utils.expectThrow(openSTValue.confirmRedemptionIntent(checkUuid, redeemer, nonce, amountUT, redemptionUnlockHeight, redemptionIntentHash, { from: registrar }));
+			redemptionIntentHash = await openSTValue.hashRedemptionIntent.call(checkUuid, redeemer, nonce, amountUT, redemptionUnlockHeight, lockR.l);
+            await Utils.expectThrow(openSTValue.confirmRedemptionIntent(checkUuid, redeemer, nonce, amountUT, redemptionUnlockHeight, lockR.l, redemptionIntentHash, { from: registrar }));
 		})
 
 		it('successfully confirms', async () => {
@@ -407,12 +407,12 @@ contract('OpenSTValue', function(accounts) {
 			stakingIntentHash = result.logs[0].args._stakingIntentHash;
 			await openSTValue.processStaking(stakingIntentHash, lock.s, { from: accounts[0] });
 
-			redemptionIntentHash = await openSTValue.hashRedemptionIntent.call(checkUuid, redeemer, nonce, amountUT, redemptionUnlockHeight);
-			var confirmReturns = await openSTValue.confirmRedemptionIntent.call(checkUuid, redeemer, nonce, amountUT, redemptionUnlockHeight, redemptionIntentHash, { from: registrar })
+			redemptionIntentHash = await openSTValue.hashRedemptionIntent.call(checkUuid, redeemer, nonce, amountUT, redemptionUnlockHeight, lockR.l);
+			var confirmReturns = await openSTValue.confirmRedemptionIntent.call(checkUuid, redeemer, nonce, amountUT, redemptionUnlockHeight, lockR.l, redemptionIntentHash, { from: registrar })
 			var amountST = confirmReturns[0];
 			assert.equal(amountST, amountUT / conversionRate);
 
-      result = await openSTValue.confirmRedemptionIntent(checkUuid, redeemer, nonce, amountUT, redemptionUnlockHeight, redemptionIntentHash, { from: registrar });
+	        result = await openSTValue.confirmRedemptionIntent(checkUuid, redeemer, nonce, amountUT, redemptionUnlockHeight, lockR.l, redemptionIntentHash, { from: registrar });
 			var blocks_to_wait_short = await openSTValue.blocksToWaitShort.call();
 
 			var blockNumber = web3.eth.blockNumber;
@@ -421,8 +421,8 @@ contract('OpenSTValue', function(accounts) {
 		})
 
 		it('fails to confirm a replay', async () => {
-			redemptionIntentHash = await openSTValue.hashRedemptionIntent.call(checkUuid, redeemer, nonce, amountUT, redemptionUnlockHeight);
-            await Utils.expectThrow(openSTValue.confirmRedemptionIntent(checkUuid, redeemer, nonce, amountUT, redemptionUnlockHeight, redemptionIntentHash, { from: registrar }));
+			redemptionIntentHash = await openSTValue.hashRedemptionIntent.call(checkUuid, redeemer, nonce, amountUT, redemptionUnlockHeight, lockR.l);
+            await Utils.expectThrow(openSTValue.confirmRedemptionIntent(checkUuid, redeemer, nonce, amountUT, redemptionUnlockHeight, lockR.l, redemptionIntentHash, { from: registrar }));
 		})
 
 		// Fails because logic does not prevent attempting to redeem 1 UTWei when the conversion rate is greater than 1
@@ -430,18 +430,20 @@ contract('OpenSTValue', function(accounts) {
 			nonce = await openSTValue.getNextNonce.call(redeemer);
 
 			// 1 STWei == 10 UTWei at the given conversion rate
-			redemptionIntentHash = await openSTValue.hashRedemptionIntent.call(checkUuid, redeemer, nonce, 1, redemptionUnlockHeight);
-            await Utils.expectThrow(openSTValue.confirmRedemptionIntent(checkUuid, redeemer, nonce, 1, redemptionUnlockHeight, redemptionIntentHash, { from: registrar }));
+			redemptionIntentHash = await openSTValue.hashRedemptionIntent.call(checkUuid, redeemer, nonce, 1, redemptionUnlockHeight, lockR.l);
+            await Utils.expectThrow(openSTValue.confirmRedemptionIntent(checkUuid, redeemer, nonce, 1, redemptionUnlockHeight, lockR.l, redemptionIntentHash, { from: registrar }));
 		})
 	})
 
 	describe('ProcessUnstaking', async () => {
 		var redeemer 				= accounts[2];
+		var notRedeemer				= accounts[5];
 		var redemptionIntentHash 	= null;
 		var redemptionUnlockHeight 	= 80668;
 		var amountUT 				= 1 * conversionRate;
 
 		const lock = HashLock.getHashLock();
+		const lockR = HashLock.getHashLock();
 
 		context('when expirationHeight is > block number', async () => {
 			before(async () => {
@@ -458,20 +460,16 @@ contract('OpenSTValue', function(accounts) {
 				result = await openSTValue.stake(checkUuid, 1, accounts[0], lock.l, { from: accounts[0] });
 				stakingIntentHash = result.logs[0].args._stakingIntentHash;
 				await openSTValue.processStaking(stakingIntentHash, lock.s, { from: accounts[0] });
-				redemptionIntentHash = await openSTValue.hashRedemptionIntent.call(checkUuid, redeemer, nonce, amountUT, redemptionUnlockHeight);
-	            await openSTValue.confirmRedemptionIntent(checkUuid, redeemer, nonce, amountUT, redemptionUnlockHeight, redemptionIntentHash, { from: registrar });
+				redemptionIntentHash = await openSTValue.hashRedemptionIntent.call(checkUuid, redeemer, nonce, amountUT, redemptionUnlockHeight, lockR.l);
+	            await openSTValue.confirmRedemptionIntent(checkUuid, redeemer, nonce, amountUT, redemptionUnlockHeight, lockR.l, redemptionIntentHash, { from: registrar });
 		    })
 
 			it('fails to process when redemptionIntentHash is empty', async () => {
-	            await Utils.expectThrow(openSTValue.processUnstaking("", { from: redeemer }));
-			})
-
-			it('fails to process when redeemer is not msg.sender', async () => {
-	            await Utils.expectThrow(openSTValue.processUnstaking(redemptionIntentHash, { from: accounts[0] }));
+	            await Utils.expectThrow(openSTValue.processUnstaking("", lockR.s, { from: notRedeemer }));
 			})
 
 			it('fails to process when utility token does not have a simpleStake address', async () => {
-	            await Utils.expectThrow(openSTValue.processUnstaking("bad hash", { from: accounts[0] }));
+	            await Utils.expectThrow(openSTValue.processUnstaking("bad hash", lockR.s, { from: notRedeemer }));
 			})
 
 			it('successfully processes', async () => {
@@ -479,7 +477,7 @@ contract('OpenSTValue', function(accounts) {
 				var redeemerBal = await valueToken.balanceOf.call(redeemer);
 				assert.equal(stakeBal.toNumber(), 1);
 				assert.equal(redeemerBal.toNumber(), 0);
-				result = await openSTValue.processUnstaking(redemptionIntentHash, { from: redeemer });
+				result = await openSTValue.processUnstaking(redemptionIntentHash, lockR.s, { from: notRedeemer });
 
 				stakeBal = await valueToken.balanceOf.call(stake);
 				redeemerBal = await valueToken.balanceOf.call(redeemer);
@@ -489,7 +487,7 @@ contract('OpenSTValue', function(accounts) {
 			})
 
 			it('fails to reprocess', async () => {
-	            await Utils.expectThrow(openSTValue.processUnstaking(redemptionIntentHash, { from: redeemer }));
+	            await Utils.expectThrow(openSTValue.processUnstaking(redemptionIntentHash, lockR.s, { from: notRedeemer }));
 			})
 		})
 	})
@@ -629,15 +627,17 @@ contract('OpenSTValue', function(accounts) {
 	// Revert Unstaking
 	describe('Revert Unstaking', async () => {
 
-		var staker 									= accounts[0];
-		var redeemer 								= accounts[2];
-		var redemptionIntentHash 		= null;
+		var staker 					= accounts[0];
+		var redeemer 				= accounts[2];
+		var notRedeemer				= accounts[5];
+		var redemptionIntentHash 	= null;
 		var redemptionUnlockHeight 	= 80668;
-		var amountST 								= new BigNumber(web3.toWei(1, "ether"));
-		var amountUT 								= new BigNumber(amountST * conversionRate);
-		var externalUser 						= accounts[7];
+		var amountST 				= new BigNumber(web3.toWei(1, "ether"));
+		var amountUT 				= new BigNumber(amountST * conversionRate);
+		var externalUser 			= accounts[7];
 
 		const lock = HashLock.getHashLock();
+		const lockR = HashLock.getHashLock();
 
 		context('Revert Unstaking before ProcessUnstaking ', async () => {
 			before(async () => {
@@ -655,8 +655,8 @@ contract('OpenSTValue', function(accounts) {
 				result = await openSTValue.stake(checkUuid, amountST, staker, lock.l, { from: staker });
 				stakingIntentHash = result.logs[0].args._stakingIntentHash;
 				await openSTValue.processStaking(stakingIntentHash, lock.s, { from: staker });
-				redemptionIntentHash = await openSTValue.hashRedemptionIntent.call(checkUuid, redeemer, nonce, amountUT, redemptionUnlockHeight);
-				await openSTValue.confirmRedemptionIntent(checkUuid, redeemer, nonce, amountUT, redemptionUnlockHeight, redemptionIntentHash, { from: registrar });
+				redemptionIntentHash = await openSTValue.hashRedemptionIntent.call(checkUuid, redeemer, nonce, amountUT, redemptionUnlockHeight, lockR.l);
+				await openSTValue.confirmRedemptionIntent(checkUuid, redeemer, nonce, amountUT, redemptionUnlockHeight, lockR.l, redemptionIntentHash, { from: registrar });
 
 			});
 			
@@ -717,12 +717,12 @@ contract('OpenSTValue', function(accounts) {
 				result = await openSTValue.stake(checkUuid, amountST, staker, lock.l, { from: staker });
 				stakingIntentHash = result.logs[0].args._stakingIntentHash;
 				await openSTValue.processStaking(stakingIntentHash, lock.s, { from: staker });
-				redemptionIntentHash = await openSTValue.hashRedemptionIntent.call(checkUuid, redeemer, nonce, amountUT, redemptionUnlockHeight);
-				await openSTValue.confirmRedemptionIntent(checkUuid, redeemer, nonce, amountUT, redemptionUnlockHeight, redemptionIntentHash, { from: registrar });
+				redemptionIntentHash = await openSTValue.hashRedemptionIntent.call(checkUuid, redeemer, nonce, amountUT, redemptionUnlockHeight, lockR.l);
+				await openSTValue.confirmRedemptionIntent(checkUuid, redeemer, nonce, amountUT, redemptionUnlockHeight, lockR.l, redemptionIntentHash, { from: registrar });
 
 
 				// Successfull ProcessUnstaking				
-				processUnstakingResult = await openSTValue.processUnstaking(redemptionIntentHash, { from: redeemer });				
+				processUnstakingResult = await openSTValue.processUnstaking(redemptionIntentHash, lockR.s, { from: notRedeemer });
 				await OpenSTValue_utils.checkProcessedUnstakeEvent(processUnstakingResult.logs[0], checkUuid, redemptionIntentHash, stake, redeemer, amountST);
 
 			});

--- a/test/OpenSTValue_utils.js
+++ b/test/OpenSTValue_utils.js
@@ -148,7 +148,7 @@ module.exports.checkStakingIntentDeclaredEventProtocol = (event, _uuid, _staker,
 	assert.equal(event.args._chainIdUtility.toNumber(), _chainIdUtility.toNumber());
 }
 
-module.exports.checkProcessedStakeEvent = (event, _uuid, _stakingIntentHash, _stake, _staker, _amountST, _amountUT) => {
+module.exports.checkProcessedStakeEvent = (event, _uuid, _stakingIntentHash, _stake, _staker, _amountST, _amountUT, _unlockSecret) => {
 	if (Number.isInteger(_amountST)) {
 		_amountST = new BigNumber(_amountST);
 	}
@@ -164,6 +164,7 @@ module.exports.checkProcessedStakeEvent = (event, _uuid, _stakingIntentHash, _st
 	assert.equal(event.args._staker, _staker);
 	assert.equal(event.args._amountST.toNumber(), _amountST.toNumber());
 	assert.equal(event.args._amountUT.toNumber(), _amountUT.toNumber());
+	assert.equal(event.args._unlockSecret, _unlockSecret);
 }
 
 module.exports.checkRedemptionIntentConfirmedEvent = (event, _uuid, _redemptionIntentHash, _redeemer, _amountST, _amountUT, _expirationHeight) => {
@@ -210,7 +211,7 @@ module.exports.checkRedemptionIntentConfirmedEventOnProtocol = (formattedDecoded
 	assert.isAbove(_unlockHeight.toNumber(), 0);
 }
 
-module.exports.checkProcessedUnstakeEvent = (event, _uuid, _redemptionIntentHash, stake, _redeemer, _amountST) => {
+module.exports.checkProcessedUnstakeEvent = (event, _uuid, _redemptionIntentHash, stake, _redeemer, _amountST, _unlockSecret) => {
 	if (Number.isInteger(_amountST)) {
 		_amountST = new BigNumber(_amountST);
 	}
@@ -221,6 +222,7 @@ module.exports.checkProcessedUnstakeEvent = (event, _uuid, _redemptionIntentHash
 	assert.equal(event.args.stake, stake);
 	assert.equal(event.args._redeemer, _redeemer);
 	assert.equal(event.args._amountST.toNumber(), _amountST.toNumber());
+	assert.equal(event.args._unlockSecret, _unlockSecret);
 }
 
 module.exports.checkRevertStakingEventProtocol = (event, _uuid, _stakingIntentHash, _staker, _amountST, _amountUT) => {

--- a/test/Protocol.js
+++ b/test/Protocol.js
@@ -319,7 +319,7 @@ contract('OpenST', function(accounts) {
 				const result = await openSTValue.processStaking(stakingIntentHash, lockBT.s, { from: stakerVC });
 
 				openSTValueUtils.checkProcessedStakeEvent(result.logs[0], registeredBrandedTokenUuid, stakingIntentHash,
-					btSimpleStakeContractAddress, stakerVC, AMOUNT_ST, AMOUNT_BT);
+					btSimpleStakeContractAddress, stakerVC, AMOUNT_ST, AMOUNT_BT, lockBT.s);
 
 				utils.logResponse(result, "OpenSTValue.processStaking");
 
@@ -330,7 +330,7 @@ contract('OpenST', function(accounts) {
 				const result = await openSTUtility.processMinting(stakingIntentHash, lockBT.s, { from: stakerUC });
 
 				openSTUtilityUtils.checkProcessedMintEvent(result.logs[0], registeredBrandedTokenUuid, stakingIntentHash,
-					registeredBrandedToken, stakerVC, beneficiary, AMOUNT_BT);
+					registeredBrandedToken, stakerVC, beneficiary, AMOUNT_BT, lockBT.s);
 
 				utils.logResponse(result, "OpenSTValue.processminting");
 			});
@@ -424,7 +424,7 @@ contract('OpenST', function(accounts) {
 				var processRedeemingResult = await openSTUtility.processRedeeming(redemptionIntentHash, lockRedeem.s, { from: redeemer });
 
 				openSTUtilityUtils.checkProcessedRedemptionEvent(processRedeemingResult.logs[0], registeredBrandedTokenUuid, redemptionIntentHash,
-					brandedToken.address, redeemer, REDEEM_AMOUNT_BT)
+					brandedToken.address, redeemer, REDEEM_AMOUNT_BT, lockRedeem.s)
 
 				utils.logResponse(processRedeemingResult, "openSTUtility.processRedeeming");
 
@@ -435,7 +435,7 @@ contract('OpenST', function(accounts) {
 				var processUnstakeResult = await openSTValue.processUnstaking(redemptionIntentHash, lockRedeem.s, { from: redeemer });
 
 				openSTValueUtils.checkProcessedUnstakeEvent(processUnstakeResult.logs[0], registeredBrandedTokenUuid, redemptionIntentHash,
-					btSimpleStakeContractAddress, redeemer, redeemedAmountST);
+					btSimpleStakeContractAddress, redeemer, redeemedAmountST, lockRedeem.s);
 
 				utils.logResponse(processUnstakeResult, "openSTValue.processUnstaking");
 
@@ -485,7 +485,7 @@ contract('OpenST', function(accounts) {
 				var processRedeemingResult = await openSTUtility.processRedeeming(redemptionIntentHash, lockRedeem.s, { from: redeemer });
 
 				openSTUtilityUtils.checkProcessedRedemptionEvent(processRedeemingResult.logs[0], uuidSTP, redemptionIntentHash,
-					stPrime.address, redeemer, REDEEM_AMOUNT_STPRIME)
+					stPrime.address, redeemer, REDEEM_AMOUNT_STPRIME, lockRedeem.s);
 
 				utils.logResponse(processRedeemingResult, "openSTUtility.STPrime.processRedeeming");
 
@@ -497,7 +497,7 @@ contract('OpenST', function(accounts) {
 
 				var event = processUnstakeResult.logs[0];
 				openSTValueUtils.checkProcessedUnstakeEvent(event, uuidSTP, redemptionIntentHash,
-					stPrimeSimpleStakeContractAddress, redeemer, REDEEM_AMOUNT_STPRIME);
+					stPrimeSimpleStakeContractAddress, redeemer, REDEEM_AMOUNT_STPRIME, lockRedeem.s);
 				utils.logResponse(processUnstakeResult, "openSTValue.STPrime.processUnstaking");
 
 			});
@@ -953,7 +953,7 @@ contract('OpenST', function(accounts) {
 				var processRedeemingResult = await openSTUtility.processRedeeming(redemptionIntentHash, lockRedeem.s, { from: redeemer });
 
 				openSTUtilityUtils.checkProcessedRedemptionEvent(processRedeemingResult.logs[0], registeredBrandedTokenUuid, redemptionIntentHash,
-					brandedToken.address, redeemer, REDEEM_AMOUNT_BT)
+					brandedToken.address, redeemer, REDEEM_AMOUNT_BT, lockRedeem.s);
 
 				utils.logResponse(processRedeemingResult, "openSTUtility.revertUnstake.processRedeeming");
 

--- a/test/Protocol.js
+++ b/test/Protocol.js
@@ -69,7 +69,8 @@ contract('OpenST', function(accounts) {
 	const AMOUNT_ST = new BigNumber(web3.toWei(1000, "ether"));
 	const AMOUNT_BT = new BigNumber(AMOUNT_ST*conversionRate);
 	const REDEEM_AMOUNT_BT = new BigNumber(web3.toWei(5, "ether"));
-	const REDEEM_AMOUNT_STPRIME = new BigNumber(web3.toWei(15, "ether"));
+	const FUND_AMOUNT_STPRIME = new BigNumber(web3.toWei(15, "ether"));
+	const REDEEM_AMOUNT_STPRIME = new BigNumber(web3.toWei(10, "ether"));
 
 	describe('Setup Utility chain with Simple Token Prime', function () {
 
@@ -366,9 +367,9 @@ contract('OpenST', function(accounts) {
 			it("transfer STPrime to Redeemer", async() => {
 
 				var redeemerBalanceBeforeTransfer = await web3.eth.getBalance(redeemer).toNumber();
-				result = await web3.eth.sendTransaction({ from: beneficiary, to: redeemer, value: REDEEM_AMOUNT_STPRIME ,gasPrice: '0x12A05F200' });
+				result = await web3.eth.sendTransaction({ from: beneficiary, to: redeemer, value: FUND_AMOUNT_STPRIME ,gasPrice: '0x12A05F200' });
 				var redeemerBalanceAfterTransfer = await web3.eth.getBalance(redeemer).toNumber();
-				Assert.equal((redeemerBalanceBeforeTransfer+(REDEEM_AMOUNT_STPRIME.toNumber())), redeemerBalanceAfterTransfer);
+				Assert.equal((redeemerBalanceBeforeTransfer+(FUND_AMOUNT_STPRIME.toNumber())), redeemerBalanceAfterTransfer);
 
 			});
 
@@ -382,6 +383,7 @@ contract('OpenST', function(accounts) {
 		});
 
 		context('Redeem and Unstake Branded Token', function() {
+			const lockRedeem = HashLock.getHashLock();
 
 			it("approve branded token", async() => {
 
@@ -394,7 +396,7 @@ contract('OpenST', function(accounts) {
 			it("call redeem", async() => {
 
 				nonce = await openSTValue.getNextNonce.call(redeemer);
-				var redeemResult = await openSTUtility.redeem(registeredBrandedTokenUuid, REDEEM_AMOUNT_BT, nonce, { from: redeemer });
+				var redeemResult = await openSTUtility.redeem(registeredBrandedTokenUuid, REDEEM_AMOUNT_BT, nonce, lockRedeem.l, { from: redeemer });
 				redemptionIntentHash = redeemResult.logs[0].args._redemptionIntentHash;
 				unlockHeight = redeemResult.logs[0].args._unlockHeight;
 				openSTUtilityUtils.checkRedemptionIntentDeclaredEvent(redeemResult.logs[0], registeredBrandedTokenUuid, redemptionIntentHash, brandedToken.address,
@@ -406,7 +408,7 @@ contract('OpenST', function(accounts) {
 			it("confirm redemption intent", async() => {
 
 				var confirmRedemptionResult = await registrarVC.confirmRedemptionIntent( openSTValue.address, registeredBrandedTokenUuid,
-				redeemer, nonce, REDEEM_AMOUNT_BT, unlockHeight, redemptionIntentHash, { from: intercommVC });
+				redeemer, nonce, REDEEM_AMOUNT_BT, unlockHeight, lockRedeem.l, redemptionIntentHash, { from: intercommVC });
 
 				var formattedDecodedEvents = web3EventsDecoder.perform(confirmRedemptionResult.receipt, openSTValue.address, openSTValueArtifacts.abi);
 				redeemedAmountST = (REDEEM_AMOUNT_BT/conversionRate);
@@ -419,7 +421,7 @@ contract('OpenST', function(accounts) {
 
 			it("process redemption", async() => {
 
-				var processRedeemingResult = await openSTUtility.processRedeeming(redemptionIntentHash, { from: redeemer });
+				var processRedeemingResult = await openSTUtility.processRedeeming(redemptionIntentHash, lockRedeem.s, { from: redeemer });
 
 				openSTUtilityUtils.checkProcessedRedemptionEvent(processRedeemingResult.logs[0], registeredBrandedTokenUuid, redemptionIntentHash,
 					brandedToken.address, redeemer, REDEEM_AMOUNT_BT)
@@ -430,7 +432,7 @@ contract('OpenST', function(accounts) {
 
 			it("process unstake", async() => {
 
-				var processUnstakeResult = await openSTValue.processUnstaking(redemptionIntentHash, { from: redeemer });
+				var processUnstakeResult = await openSTValue.processUnstaking(redemptionIntentHash, lockRedeem.s, { from: redeemer });
 
 				openSTValueUtils.checkProcessedUnstakeEvent(processUnstakeResult.logs[0], registeredBrandedTokenUuid, redemptionIntentHash,
 					btSimpleStakeContractAddress, redeemer, redeemedAmountST);
@@ -447,13 +449,14 @@ contract('OpenST', function(accounts) {
 			});
 
 		});
-/*
+
 		context('Redeem and Unstake STPrime', function() {
+			const lockRedeem = HashLock.getHashLock();
 
 			it("call redeem", async() => {
 
 				nonce = await openSTValue.getNextNonce.call(redeemer);
-				var redeemResult = await openSTUtility.redeemSTPrime(nonce, { from: redeemer, value: REDEEM_AMOUNT_STPRIME });
+				var redeemResult = await openSTUtility.redeemSTPrime(nonce, lockRedeem.l, { from: redeemer, value: REDEEM_AMOUNT_STPRIME });
 				redemptionIntentHash = redeemResult.logs[0].args._redemptionIntentHash;
 				unlockHeight = redeemResult.logs[0].args._unlockHeight;
 				openSTUtilityUtils.checkRedemptionIntentDeclaredEvent(redeemResult.logs[0], uuidSTP, redemptionIntentHash, stPrime.address,
@@ -466,7 +469,7 @@ contract('OpenST', function(accounts) {
 			it("confirm redemption intent", async() => {
 
 				var confirmRedemptionResult = await registrarVC.confirmRedemptionIntent( openSTValue.address, uuidSTP, redeemer, nonce,
-					REDEEM_AMOUNT_STPRIME, unlockHeight, redemptionIntentHash, { from: intercommVC });
+					REDEEM_AMOUNT_STPRIME, unlockHeight, lockRedeem.l, redemptionIntentHash, { from: intercommVC });
 
 				var formattedDecodedEvents = web3EventsDecoder.perform(confirmRedemptionResult.receipt,
 					openSTValue.address, openSTValueArtifacts.abi);
@@ -479,7 +482,7 @@ contract('OpenST', function(accounts) {
 
 			it("process redemption", async() => {
 
-				var processRedeemingResult = await openSTUtility.processRedeeming(redemptionIntentHash, { from: redeemer });
+				var processRedeemingResult = await openSTUtility.processRedeeming(redemptionIntentHash, lockRedeem.s, { from: redeemer });
 
 				openSTUtilityUtils.checkProcessedRedemptionEvent(processRedeemingResult.logs[0], uuidSTP, redemptionIntentHash,
 					stPrime.address, redeemer, REDEEM_AMOUNT_STPRIME)
@@ -490,7 +493,7 @@ contract('OpenST', function(accounts) {
 
 			it("process unstake", async() => {
 
-				var processUnstakeResult = await openSTValue.processUnstaking(redemptionIntentHash, { from: redeemer });
+				var processUnstakeResult = await openSTValue.processUnstaking(redemptionIntentHash, lockRedeem.s, { from: redeemer });
 
 				var event = processUnstakeResult.logs[0];
 				openSTValueUtils.checkProcessedUnstakeEvent(event, uuidSTP, redemptionIntentHash,
@@ -631,113 +634,115 @@ contract('OpenST', function(accounts) {
 					stakerVC, beneficiary, AMOUNT_BT)
 			});
 		});
-/*
-	  //   // // After process staking, revertStake cannot be called but revertMinting can still be called.
-	  //   // // As of now ST get stuck in SimpleStake Contract for the staker which should ideally be returned after revertMinting
-	  //   // // Checking the ST balance in SimpleStake as non zero which will start failing once we fix the issue of
-	  //   // // releasing ST after revertMinting as well
-	  //   context('Revert minting after process Staking', function() {
 
-			// var previousSTBalance = null;
+	    // // After process staking, revertStake cannot be called but revertMinting can still be called.
+	    // // As of now ST get stuck in SimpleStake Contract for the staker which should ideally be returned after revertMinting
+	    // // Checking the ST balance in SimpleStake as non zero which will start failing once we fix the issue of
+	    // // releasing ST after revertMinting as well
+	    context('Revert minting after process Staking', function() {
 
-			// it("previous balance on simple stake", async() => {
-			// 	previousSTBalance = await btSimpleStake.getTotalStake.call();
-			// });
+			const lockStake = HashLock.getHashLock();
+			var previousSTBalance = null;
 
-			// it("call stake ", async() => {
+			it("previous balance on simple stake", async() => {
+				previousSTBalance = await btSimpleStake.getTotalStake.call();
+			});
 
-			// 	// transfer ST to requester account
-			// 	Assert.ok(await simpleToken.transfer(requester, AMOUNT_ST, { from: deployMachine }));
-			// 	Assert.ok(await simpleToken.approve(openSTValue.address, AMOUNT_ST, { from: requester }));
+			it("call stake", async() => {
 
-			// 	nonceBT = await openSTValue.getNextNonce.call(requester);
-			// 	// requester calls OpenSTValue.stake to initiate the staking for Branded Token with registeredBrandedTokenUuid
-			// 	// with requester as the beneficiary
-			// 	var stakeResult = await openSTValue.stake(registeredBrandedTokenUuid, AMOUNT_ST, requester, { from: requester });
+				// transfer ST to requester account
+				Assert.ok(await simpleToken.transfer(stakerVC, AMOUNT_ST, { from: deployMachine }));
+				Assert.ok(await simpleToken.approve(openSTValue.address, AMOUNT_ST, { from: stakerVC }));
 
-			// 	openSTValueUtils.checkStakingIntentDeclaredEventProtocol(stakeResult.logs[0], registeredBrandedTokenUuid, requester, nonceBT,
-			// 		requester, AMOUNT_ST, AMOUNT_BT, CHAINID_UTILITY);
+				nonceBT = await openSTValue.getNextNonce.call(stakerVC);
+				// stakerVC calls OpenSTValue.stake to initiate the staking for Branded Token with registeredBrandedTokenUuid
+				// with stakerVC as the beneficiary
+				var stakeResult = await openSTValue.stake(registeredBrandedTokenUuid, AMOUNT_ST, beneficiary, lockStake.l, { from: stakerVC });
 
-			// 	stakingIntentHash = stakeResult.logs[0].args._stakingIntentHash;
-			// 	unlockHeight = stakeResult.logs[0].args._unlockHeight;
-			// 	nonceBT = stakeResult.logs[0].args._stakerNonce;
+				openSTValueUtils.checkStakingIntentDeclaredEventProtocol(stakeResult.logs[0], registeredBrandedTokenUuid, stakerVC, nonceBT,
+					beneficiary, AMOUNT_ST, AMOUNT_BT, CHAINID_UTILITY);
 
-   //  	});
+				stakingIntentHash = stakeResult.logs[0].args._stakingIntentHash;
+				unlockHeight = stakeResult.logs[0].args._unlockHeight;
+				nonceBT = stakeResult.logs[0].args._stakerNonce;
 
-   //    it("confirm staking intent for Branded Token", async() => {
+	    	});
 
-   //      const result = await registrarUC.confirmStakingIntent(openSTUtility.address, registeredBrandedTokenUuid,
-   //      requester, nonceBT, requester, AMOUNT_ST, AMOUNT_BT, unlockHeight, stakingIntentHash, { from: intercommUC });
+			it("confirm staking intent for Branded Token", async() => {
 
-			// 	var formattedDecodedEvents = web3EventsDecoder.perform(result.receipt, openSTUtility.address, openSTUtilityArtifacts.abi);
+			    const result = await registrarUC.confirmStakingIntent(openSTUtility.address, registeredBrandedTokenUuid,
+			    stakerVC, nonceBT, beneficiary, AMOUNT_ST, AMOUNT_BT, unlockHeight, lockStake.l, stakingIntentHash, { from: intercommUC });
 
-			// 	openSTUtilityUtils.checkStakingIntentConfirmedEventOnProtocol(formattedDecodedEvents, registeredBrandedTokenUuid,
-			// 		stakingIntentHash, requester, requester, AMOUNT_ST, AMOUNT_BT);
+				var formattedDecodedEvents = web3EventsDecoder.perform(result.receipt, openSTUtility.address, openSTUtilityArtifacts.abi);
 
-			// 	utils.logResponse(result, "OpenSTUtility.confirmStakingIntent");
+				openSTUtilityUtils.checkStakingIntentConfirmedEventOnProtocol(formattedDecodedEvents, registeredBrandedTokenUuid,
+					stakingIntentHash, stakerVC, beneficiary, AMOUNT_ST, AMOUNT_BT);
 
-   //  	});
+				utils.logResponse(result, "OpenSTUtility.confirmStakingIntent");
 
-   //    it("process staking", async () => {
-   //      const o = await openSTValue.processStaking(stakingIntentHash, { from: requester });
-   //    	utils.logResponse(o, "OpenSTValue.processStaking");
-   //  	});
+			});
 
-   //    // Before wait time as passed
-   //    it('fails to revertMinting before expiration block', async () => {
-   //      var waitTime = await openSTUtility.blocksToWaitShort.call();
-		 // 		waitTime = waitTime.toNumber();
-   //    	// Wait time less 1 block for preceding test case and 1 block because condition is <=
+			it("process staking", async () => {
+				const o = await openSTValue.processStaking(stakingIntentHash, lockStake.s, { from: stakerVC });
+				utils.logResponse(o, "OpenSTValue.processStaking");
+			});
 
-   //    	const amount = new BigNumber(1);
-   //    	for (var i = 0; i < waitTime/2; i++) {
-   //        await web3.eth.sendTransaction({ from: owner, to: admin, value: amount });
-   //        await web3.eth.sendTransaction({ from: admin, to: owner, value: amount });
-   //    	}
-   //  	});
+			// Before wait time as passed
+			it('fails to revertMinting before expiration block', async () => {
+				var waitTime = await openSTUtility.blocksToWaitShort.call();
+					waitTime = waitTime.toNumber();
+				// Wait time less 1 block for preceding test case and 1 block because condition is <=
 
-   //    // Before wait time as passed
-   //    // Revert staking called after unlock block
-   //    it('fails to revertStaking before waiting period ends', async () => {
-   //      var waitTime = await openSTValue.blocksToWaitLong.call();
-   //    	waitTime = waitTime.toNumber();
-   //    	// Wait time less 1 block for preceding test case and 1 block because condition is <=
-   //    	const amount = new BigNumber(1);				
-   //    	for (var i = 0; i < waitTime/2; i++) {
-   //      	await web3.eth.sendTransaction({ from: owner, to: admin, value: amount });
-   //      	await web3.eth.sendTransaction({ from: admin, to: owner, value: amount });
-   //    	}
-   //  	});
+				const amount = new BigNumber(1);
+				for (var i = 0; i < waitTime/2; i++) {
+					await web3.eth.sendTransaction({ from: owner, to: admin, value: amount });
+					await web3.eth.sendTransaction({ from: admin, to: owner, value: amount });
+				}
+			});
 
-   //    it("revert staking should not be allowed after processStaking", async() => {
-   //      await utils.expectThrow(openSTValue.revertStaking(stakingIntentHash, {from: staker}));
-   //  	});
+			// Before wait time as passed
+			// Revert staking called after unlock block
+			it('fails to revertStaking before waiting period ends', async () => {
+				var waitTime = await openSTValue.blocksToWaitLong.call();
+				waitTime = waitTime.toNumber();
+				// Wait time less 1 block for preceding test case and 1 block because condition is <=
+				const amount = new BigNumber(1);
+				for (var i = 0; i < waitTime/2; i++) {
+					await web3.eth.sendTransaction({ from: owner, to: admin, value: amount });
+					await web3.eth.sendTransaction({ from: admin, to: owner, value: amount });
+				}
+			});
 
-   //    it("revert minting after expiring block height", async() => {
-   //      // Revert minting from staker user as it can be called from any external user.
-   //      // If we put this as a contraint this test case will fail
-   //      var result = await openSTUtility.revertMinting(stakingIntentHash, {from: staker});
-   //    	openSTUtilityUtils.checkRevertedMintEvent(result.logs[0], registeredBrandedTokenUuid, stakingIntentHash,
-   //      	requester, requester, AMOUNT_BT);
-   //  	});
+			it("revert staking should not be allowed after processStaking", async() => {
+				await utils.expectThrow(openSTValue.revertStaking(stakingIntentHash, { from: stakerVC }));
+			});
 
-   //    it ("validate if the ST is stuck in Simple Stake", async() => {
-			// 	var currentStBalance = await btSimpleStake.getTotalStake.call()
-			// 	var tobeBalance = previousSTBalance.toNumber() + AMOUNT_ST.toNumber();
-			// 	Assert.equal(currentStBalance.toNumber(), tobeBalance)
-			// });
+			it("revert minting after expiring block height", async() => {
+				// Revert minting from staker user as it can be called from any external user.
+				// If we put this as a contraint this test case will fail
+				var result = await openSTUtility.revertMinting(stakingIntentHash, { from: stakerVC });
+				openSTUtilityUtils.checkRevertedMintEvent(result.logs[0], registeredBrandedTokenUuid, stakingIntentHash,
+				stakerVC, beneficiary, AMOUNT_BT);
+			});
 
-   //  });
+			it ("validate if the ST is stuck in Simple Stake", async() => {
+				var currentStBalance = await btSimpleStake.getTotalStake.call()
+				var tobeBalance = previousSTBalance.toNumber() + AMOUNT_ST.toNumber();
+				Assert.equal(currentStBalance.toNumber(), tobeBalance)
+			});
+
+	    });
 
 			// SEQUENCE OF EVENTS
 		 // Call Redeem => Call RevertRedemption
 		//
 		context('call redeem then revertRedemption', function() {
+			const lockRedeem = HashLock.getHashLock();
 
 			// Redeemer should have some branded token
 			it("transfers branded token to redeemer", async() => {
 
-				var result = await brandedToken.transfer(redeemer, REDEEM_AMOUNT_BT, {from: requester});
+				var result = await brandedToken.transfer(redeemer, REDEEM_AMOUNT_BT, { from: beneficiary });
 				Assert.ok(result);
 				var balanceOfRedeemer = await brandedToken.balanceOf(redeemer);
 				Assert.equal(balanceOfRedeemer, REDEEM_AMOUNT_BT.toNumber());
@@ -753,7 +758,7 @@ contract('OpenST', function(accounts) {
 				Assert.ok(approveResult);
 
 				nonce = await openSTValue.getNextNonce.call(redeemer);
-				var redeemResult = await openSTUtility.redeem(registeredBrandedTokenUuid, REDEEM_AMOUNT_BT, nonce, { from: redeemer });
+				var redeemResult = await openSTUtility.redeem(registeredBrandedTokenUuid, REDEEM_AMOUNT_BT, nonce, lockRedeem.l, { from: redeemer });
 				redemptionIntentHash = redeemResult.logs[0].args._redemptionIntentHash;
 				unlockHeight = redeemResult.logs[0].args._unlockHeight;
 				openSTUtilityUtils.checkRedemptionIntentDeclaredEvent(redeemResult.logs[0], registeredBrandedTokenUuid, redemptionIntentHash,
@@ -799,6 +804,7 @@ contract('OpenST', function(accounts) {
 		 // Redeem => confirmRedemptionIntent => revertRedemption => revertUnstaking
 		//
 		context('call redeem then confirmRedemptionIntent then revertRedemption then revertUnstaking', function() {
+			const lockRedeem = HashLock.getHashLock();
 
 			// Since we reverted redemption in above case we don't need to transfer again as redeemer will already have REDEEM_AMOUNT_BT balance
 			it("check branded token balance of redeemer", async() => {
@@ -815,7 +821,7 @@ contract('OpenST', function(accounts) {
 				Assert.ok(approveResult);
 
 				nonce = await openSTValue.getNextNonce.call(redeemer);
-				var redeemResult = await openSTUtility.redeem(registeredBrandedTokenUuid, REDEEM_AMOUNT_BT, nonce, { from: redeemer });
+				var redeemResult = await openSTUtility.redeem(registeredBrandedTokenUuid, REDEEM_AMOUNT_BT, nonce, lockRedeem.l, { from: redeemer });
 				redemptionIntentHash = redeemResult.logs[0].args._redemptionIntentHash;
 				unlockHeight = redeemResult.logs[0].args._unlockHeight;
 				openSTUtilityUtils.checkRedemptionIntentDeclaredEvent(redeemResult.logs[0], registeredBrandedTokenUuid, redemptionIntentHash,
@@ -829,7 +835,7 @@ contract('OpenST', function(accounts) {
 			it("calls confirmRedemptionIntent", async() => {
 
 				var confirmRedemptionResult = await registrarVC.confirmRedemptionIntent( openSTValue.address, registeredBrandedTokenUuid,
-					redeemer, nonce, REDEEM_AMOUNT_BT, unlockHeight, redemptionIntentHash, { from: intercommVC });
+					redeemer, nonce, REDEEM_AMOUNT_BT, unlockHeight, lockRedeem.l, redemptionIntentHash, { from: intercommVC });
 				var formattedDecodedEvents = web3EventsDecoder.perform(confirmRedemptionResult.receipt, openSTValue.address, openSTValueArtifacts.abi);
 				redeemedAmountST = (REDEEM_AMOUNT_BT/conversionRate);
 				openSTValueUtils.checkRedemptionIntentConfirmedEventOnProtocol(formattedDecodedEvents, registeredBrandedTokenUuid,
@@ -895,7 +901,7 @@ contract('OpenST', function(accounts) {
 		 // Redeem => confirmRedemptionIntent => ProcessRedemption => revertRedemption => revertUnstaking
 		//
 		context('call redeem then confirmRedemptionIntent then ProcessRedemption then revertRedemption then revertUnstaking', function() {
-
+			const lockRedeem = HashLock.getHashLock();
 			var previousSTBalance = null;
 
 			it("previous balance on simple stake contract", async() => {
@@ -919,7 +925,7 @@ contract('OpenST', function(accounts) {
 				Assert.ok(approveResult);
 
 				nonce = await openSTValue.getNextNonce.call(redeemer);
-				var redeemResult = await openSTUtility.redeem(registeredBrandedTokenUuid, REDEEM_AMOUNT_BT, nonce, { from: redeemer });
+				var redeemResult = await openSTUtility.redeem(registeredBrandedTokenUuid, REDEEM_AMOUNT_BT, nonce, lockRedeem.l, { from: redeemer });
 				redemptionIntentHash = redeemResult.logs[0].args._redemptionIntentHash;
 				unlockHeight = redeemResult.logs[0].args._unlockHeight;
 				openSTUtilityUtils.checkRedemptionIntentDeclaredEvent(redeemResult.logs[0], registeredBrandedTokenUuid, redemptionIntentHash,
@@ -933,7 +939,7 @@ contract('OpenST', function(accounts) {
 			it("calls confirmRedemptionIntent", async() => {
 
 				var confirmRedemptionResult = await registrarVC.confirmRedemptionIntent( openSTValue.address, registeredBrandedTokenUuid,
-				redeemer, nonce, REDEEM_AMOUNT_BT, unlockHeight, redemptionIntentHash, { from: intercommVC });
+				redeemer, nonce, REDEEM_AMOUNT_BT, unlockHeight, lockRedeem.l, redemptionIntentHash, { from: intercommVC });
 				var formattedDecodedEvents = web3EventsDecoder.perform(confirmRedemptionResult.receipt, openSTValue.address, openSTValueArtifacts.abi);
 				redeemedAmountST = (REDEEM_AMOUNT_BT/conversionRate);
 				openSTValueUtils.checkRedemptionIntentConfirmedEventOnProtocol(formattedDecodedEvents, registeredBrandedTokenUuid,
@@ -944,7 +950,7 @@ contract('OpenST', function(accounts) {
 
 			it("process redemption", async() => {
 
-				var processRedeemingResult = await openSTUtility.processRedeeming(redemptionIntentHash, { from: redeemer });
+				var processRedeemingResult = await openSTUtility.processRedeeming(redemptionIntentHash, lockRedeem.s, { from: redeemer });
 
 				openSTUtilityUtils.checkProcessedRedemptionEvent(processRedeemingResult.logs[0], registeredBrandedTokenUuid, redemptionIntentHash,
 					brandedToken.address, redeemer, REDEEM_AMOUNT_BT)
@@ -1020,6 +1026,5 @@ contract('OpenST', function(accounts) {
 			});
 
 		});
-*/
 	});
 });

--- a/test/Registrar.js
+++ b/test/Registrar.js
@@ -198,6 +198,7 @@ contract('Registrar', function(accounts) {
 		const amountUTRedeemed 	 	= (amountST * conversionRate) / amountST;
 
 		const lock = HashLock.getHashLock();
+		const lockR = HashLock.getHashLock();
 
 		before(async() => {
 	        contracts   	= await Registrar_utils.deployRegistrar(artifacts, accounts);
@@ -215,17 +216,17 @@ contract('Registrar', function(accounts) {
 	        var stakingIntentHash = result.logs[0].args._stakingIntentHash;
 			await openSTValue.processStaking(stakingIntentHash, lock.s, { from: staker });
 			nonce = await openSTValue.getNextNonce.call(staker);
-			redemptionIntentHash = await openSTValue.hashRedemptionIntent.call(uuid, staker, nonce, amountUTRedeemed, BLOCKS_TO_WAIT_LONG);
+			redemptionIntentHash = await openSTValue.hashRedemptionIntent.call(uuid, staker, nonce, amountUTRedeemed, BLOCKS_TO_WAIT_LONG, lockR.l);
 		})
 
 		it('fails to confirm by non-ops', async () => {
-            await Utils.expectThrow(registrar.confirmRedemptionIntent(openSTValue.address, uuid, staker, nonce, amountUTRedeemed, BLOCKS_TO_WAIT_LONG, redemptionIntentHash));
-            await Utils.expectThrow(registrar.confirmRedemptionIntent(openSTValue.address, uuid, staker, nonce, amountUTRedeemed, BLOCKS_TO_WAIT_LONG, redemptionIntentHash, { from: admin }));
+            await Utils.expectThrow(registrar.confirmRedemptionIntent(openSTValue.address, uuid, staker, nonce, amountUTRedeemed, BLOCKS_TO_WAIT_LONG, lockR.l, redemptionIntentHash));
+            await Utils.expectThrow(registrar.confirmRedemptionIntent(openSTValue.address, uuid, staker, nonce, amountUTRedeemed, BLOCKS_TO_WAIT_LONG, lockR.l, redemptionIntentHash, { from: admin }));
 		})
 
 		it('successfully confirms', async () => {
 			var BLOCKS_TO_WAIT_SHORT = 240;
-            var confirmReturns = await registrar.confirmRedemptionIntent.call(openSTValue.address, uuid, staker, nonce, amountUTRedeemed, BLOCKS_TO_WAIT_LONG, redemptionIntentHash, { from: ops });
+            var confirmReturns = await registrar.confirmRedemptionIntent.call(openSTValue.address, uuid, staker, nonce, amountUTRedeemed, BLOCKS_TO_WAIT_LONG, lockR.l, redemptionIntentHash, { from: ops });
 
             assert.equal(confirmReturns[0], (amountUTRedeemed / conversionRate));
             assert.ok(confirmReturns[1] > BLOCKS_TO_WAIT_SHORT);


### PR DESCRIPTION
Per handover instructions:
- updates unit tests for redeem/unstake
- updates integration tests for redeem/unstake
- include `unlockSecret` in ProcessedX events (platform will need to be notified of these changes)
