### PR TITLE
test:mocktoken.js removed 4 arguments from Mocktoken() constructor

### DIFF
--- a/test/MockToken.js
+++ b/test/MockToken.js
@@ -2,7 +2,6 @@ const Utils = require('./lib/utils.js')
 const SimpleTokenUtils = require('./SimpleToken_utils.js')
 
 const Moment = require('moment')
-const BigNumber = require('bignumber.js')
 
 const MockToken = artifacts.require("./MockToken.sol")
 
@@ -17,14 +16,9 @@ const MockToken = artifacts.require("./MockToken.sol")
 
 contract('MockToken', (accounts) => {
 
-   const DECIMALSFACTOR = new BigNumber('10').pow('18')
-
    const SYMBOL         = "MOCK"
    const NAME           = "Mock Token"
-   const DECIMALS       = 18
-   const TOTAL_SUPPLY   = new BigNumber(web3.toWei(800000000, "ether"));
    const admin          = accounts[1];
-
 
    async function createToken() {
       return await MockToken.new({ from: accounts[0], gas: 3500000 })

--- a/test/MockToken.js
+++ b/test/MockToken.js
@@ -27,7 +27,7 @@ contract('MockToken', (accounts) => {
 
 
    async function createToken() {
-      return await MockToken.new(SYMBOL, NAME, DECIMALS, TOTAL_SUPPLY, { from: accounts[0], gas: 3500000 })
+      return await MockToken.new({ from: accounts[0], gas: 3500000 })
    }
 
    describe('Basic properties', async () => {


### PR DESCRIPTION
## Error 
`truffle test MockToken.js` ->
 Contract: MockToken
    Basic properties
      1) "before all" hook
    Finalize
      2) "before all" hook

  0 passing (144ms)
  2 failing

  1) Contract: MockToken Basic properties "before all" hook:
     `Error: MockToken contract constructor expected 0 arguments, received 4
      at /usr/local/lib/node_modules/truffle/build/webpack:/~/truffle-contract/contract.js:390:1
      at new Promise (<anonymous>)
      at /usr/local/lib/node_modules/truffle/build/webpack:/~/truffle-contract/contract.js:374:1
      at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7) `

  2) Contract: MockToken Finalize "before all" hook:
     `Error: MockToken contract constructor expected 0 arguments, received 4
      at /usr/local/lib/node_modules/truffle/build/webpack:/~/truffle-contract/contract.js:390:1
      at new Promise (<anonymous>)
      at /usr/local/lib/node_modules/truffle/build/webpack:/~/truffle-contract/contract.js:374:1
      at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)`

## PostFix
`truffle test MockToken.js` ->
   Contract: MockToken
    Basic properties
      ✓ symbol
      ✓ name
    Finalize
      ✓ check properties before and after finalize (63ms)
      ✓ try to finalize a 2nd time
  4 passing (435ms)

## Issue Description
1. MockToken() fn in MockToken.sol, has zero arguments in its definition.
2. Test case MockToken.js was calling MockToken() with 4 arguments.

## Solution
Simply removed the arguments to fix the test case.

## Fixes #120 