### PR TITLE
Fixed typo in Gate:processStaking. MOSA-124

### DIFF
--- a/contracts/Gate.sol
+++ b/contracts/Gate.sol
@@ -240,10 +240,10 @@ contract Gate is ProtocolVersioned, Owned {
     require(stakeRequest.hashLock != bytes32(0));
 
     // we call processStaking for OpenSTValue and get the stakeAddress on success.
-    address stakerAddress = OpenSTValueInterface(openSTProtocol).processStaking(_stakingIntentHash, _unlockSecret);
+    address stakeAddress = OpenSTValueInterface(openSTProtocol).processStaking(_stakingIntentHash, _unlockSecret);
 
     // check if the stake address is not 0
-    require(stakerAddress != address(0));
+    require(stakeAddress != address(0));
 
     //If the msg.sender is whitelited worker then transfer the bounty amount to Workers contract
     //else transfer the bounty to msg.sender.


### PR DESCRIPTION
Resolves issue: #170 

Fixed typo in Gate::processStaking. `stakeAddress` was incorrectly named as `stakerAddress`
Ref: MOSA-124