### PR TITLE
Gate::revertStaking should not require caller to be whitelisted worker [MOSA-127]

### DIFF
--- a/test/Gate.js
+++ b/test/Gate.js
@@ -627,7 +627,16 @@ contract('Gate', function(accounts) {
 
       });
 
-      it('fails to process when already processStake is called', async () => {
+      it('successfully processes called by any account', async () => {
+
+          let stakeResult = await acceptStakeRequest(stakerAccount, stakeAmount, lock, workerAddress1, true);
+          let stakingIntentHash = stakeResult['stakingIntentHash'];
+
+          await revertStaking(stakingIntentHash, accounts[10], true);
+
+      });
+
+        it('fails to process when already processStake is called', async () => {
 
         let stakeResult = await acceptStakeRequest(stakerAccount, stakeAmount, lock, workerAddress1, true);
         let stakingIntentHash = stakeResult['stakingIntentHash'];
@@ -655,17 +664,6 @@ contract('Gate', function(accounts) {
         await revertStaking(beneficiaryAccount, workerAddress1, false);
 
       });
-
-      it('fails to process when worker is not whitelisted', async () => {
-
-        let stakeResult = await acceptStakeRequest(stakerAccount, stakeAmount, lock, workerAddress1, true);
-        let stakingIntentHash = stakeResult['stakingIntentHash'];
-
-        let workerAddress = accounts[10];
-        await revertStaking(stakingIntentHash, workerAddress, false);
-
-      });
-
 
       it('fails to processes when stakeRequest was not accepted', async () => {
 


### PR DESCRIPTION
`Gate.revertStaking` now can be called by any account, not just whitelisted worker.

GH issue: #178 
Branch: deepesh/MOSA-127

Please note:
It is mentioned in the gh issue #178 : _"If it's non whitelisted worker, then bounty is sent from OpenSTValue to msg.sender."_
This is not implemented in this PR.
user can stake amount, wait for unlock time and then revert it. User get the bounty amount :)
Please let me know if my understanding is correct.
