### PR TITLE
Add setWorkers function in gateway contract. MOSA-30

### DIFF
--- a/contracts/Gateway.sol
+++ b/contracts/Gateway.sol
@@ -58,7 +58,7 @@ contract Gateway is ProtocolVersioned, Owned {
       bytes32 _stakingIntentHash);
 
     /** Below event is emitted after successful execution of setWorkers */
-    event WorkersSet(bytes32 _uuid, WorkersInterface _workers);
+    event WorkersSet(WorkersInterface _workers);
 
     /* Storage */
 
@@ -399,7 +399,7 @@ contract Gateway is ProtocolVersioned, Owned {
         workers = _workers;
 
         //Event for workers set
-        emit WorkersSet(uuid, _workers);
+        emit WorkersSet(_workers);
 
         return true;
     }

--- a/contracts/Gateway.sol
+++ b/contracts/Gateway.sol
@@ -386,20 +386,20 @@ contract Gateway is ProtocolVersioned, Owned {
       *
       * @dev only owner can call this
       *
-      * @param _worker workers contract address
+      * @param _workers workers contract address
       *
       * @return success, boolean that specifies status of the execution
       */
-    function setWorkers(WorkersInterface _worker)
+    function setWorkers(WorkersInterface _workers)
         external
         onlyOwner()
         returns (bool /* success */)
     {
-        require(_worker != address(0));
-        workers = _worker;
+        require(_workers != address(0));
+        workers = _workers;
 
         //Event for workers set
-        emit WorkersSet(uuid, _worker);
+        emit WorkersSet(uuid, _workers);
 
         return true;
     }

--- a/contracts/Gateway.sol
+++ b/contracts/Gateway.sol
@@ -57,6 +57,9 @@ contract Gateway is ProtocolVersioned, Owned {
       uint256 _unlockHeight,
       bytes32 _stakingIntentHash);
 
+    /** Below event is emitted after successful execution of setWorkers */
+    event WorkersSet(bytes32 _uuid, WorkersInterface _workers);
+
     /* Storage */
 
     /** Storing stake requests */
@@ -377,4 +380,27 @@ contract Gateway is ProtocolVersioned, Owned {
 
         return amountST;
       }
+
+    /**
+      * @notice external function to set workers
+      *
+      * @dev only owner can call this
+      *
+      * @param _worker workers contract address
+      *
+      * @return success, boolean that specifies status of the execution
+      */
+    function setWorkers(WorkersInterface _worker)
+        external
+        onlyOwner()
+        returns (bool /* success */)
+    {
+        require(_worker != address(0));
+        workers = _worker;
+
+        //Event for workers set
+        emit WorkersSet(uuid, _worker);
+
+        return true;
+    }
 }

--- a/contracts/Gateway.sol
+++ b/contracts/Gateway.sol
@@ -395,7 +395,6 @@ contract Gateway is ProtocolVersioned, Owned {
         onlyOwner()
         returns (bool /* success */)
     {
-        require(_workers != address(0));
         workers = _workers;
 
         //Event for workers set

--- a/test/Gateway.js
+++ b/test/Gateway.js
@@ -329,6 +329,9 @@ contract('Gateway', function(accounts) {
       let result = await gateway.setWorkers(workersAddress, {from: messageSender});
       await Gateway_utils.checkWorkersSetEvent(result.logs[0], workersAddress, uuid);
 
+      let workersFromContract = await  gateway.workers.call();
+      assert.equal(workersFromContract, workersAddress);
+
     } else {
       await Utils.expectThrow(gateway.setWorkers(workersAddress, {from: messageSender}));
     }

--- a/test/Gateway.js
+++ b/test/Gateway.js
@@ -327,9 +327,9 @@ contract('Gateway', function(accounts) {
       assert.equal(response, isSuccessCase);
 
       let result = await gateway.setWorkers(workersAddress, {from: messageSender});
-      await Gateway_utils.checkWorkersSetEvent(result.logs[0], workersAddress, uuid);
+      await Gateway_utils.checkWorkersSetEvent(result.logs[0], workersAddress);
 
-      let workersFromContract = await  gateway.workers.call();
+      let workersFromContract = await gateway.workers.call();
       assert.equal(workersFromContract, workersAddress);
 
     } else {
@@ -725,11 +725,11 @@ contract('Gateway', function(accounts) {
         });
 
         it('fails to set workers when caller is not owner', async () => {
-            await setWorkers(accounts[8], accounts[2], false)
+            await setWorkers(accounts[8], accounts[2], false);
         });
 
         it('sucessfully sets workers when caller is owner', async () => {
-            await setWorkers(accounts[8], ownerAddress, true)
+            await setWorkers(accounts[8], ownerAddress, true);
         });
 
     });

--- a/test/Gateway.js
+++ b/test/Gateway.js
@@ -31,6 +31,8 @@ contract('Gateway', function(accounts) {
     , beneficiaryAccount = accounts[6]
   ;
 
+  var result, valueToken, openSTValue, uuid, gateway, workers, bounty, workerAddress1, ownerAddress;
+
   const deployGateway = async function() {
     result   = await Gateway_utils.deployGateway(artifacts, accounts);
     valueToken  = result.valueToken;
@@ -40,6 +42,7 @@ contract('Gateway', function(accounts) {
     workers = result.workers;
     bounty = result.bounty;
     workerAddress1 = result.workerAddress1;
+    ownerAddress = result.ownerAddress;
   };
 
   const approveGatewayAndRequestStake = async function (amount, beneficiary, staker, isSuccessCase) {
@@ -316,6 +319,21 @@ contract('Gateway', function(accounts) {
       hashLock: lock.l
     }
   };
+
+  const setWorkers = async function (workersAddress, messageSender, isSuccessCase) {
+
+    if (isSuccessCase){
+      let response = await gateway.setWorkers.call(workersAddress, {from: messageSender});
+      assert.equal(response, isSuccessCase);
+
+      let result = await gateway.setWorkers(workersAddress, {from: messageSender});
+      await Gateway_utils.checkWorkersSetEvent(result.logs[0], workersAddress, uuid);
+
+    } else {
+      await Utils.expectThrow(gateway.setWorkers(workersAddress, {from: messageSender}));
+    }
+  };
+
   describe('Properties', async () => {
 
     before (async () => {
@@ -695,7 +713,23 @@ contract('Gateway', function(accounts) {
         await revertStaking(stakingIntentHashParams.stakingIntentHash, workerAddress1, false);
       });
 
-    })
+    });
+
+    describe('setWorkers', async () => {
+
+        before (async () => {
+            await deployGateway();
+        });
+
+        it('fails to set workers when caller is not owner', async () => {
+            await setWorkers(accounts[8], accounts[2], false)
+        });
+
+        it('sucessfully sets workers when caller is owner', async () => {
+            await setWorkers(accounts[8], ownerAddress, true)
+        });
+
+    });
 
 });
 

--- a/test/Gateway_utils.js
+++ b/test/Gateway_utils.js
@@ -47,6 +47,7 @@ module.exports.deployGateway = async (artifacts, accounts) => {
     , admin = accounts[3]
     , ops = accounts[1]
     , registrar = accounts[5]
+    , ownerAddress = accounts[12]
   ;
 
   var core = null
@@ -72,7 +73,7 @@ module.exports.deployGateway = async (artifacts, accounts) => {
 
   checkUuid = await openSTValue.hashUuid.call(symbol, name, chainIdValue, chainIdRemote, openSTRemote, conversionRate, conversionRateDecimals);
 
-  const gateway = await Gateway.new(workers.address, bounty, checkUuid, openSTValue.address);
+  const gateway = await Gateway.new(workers.address, bounty, checkUuid, openSTValue.address, {from:ownerAddress});
 
   assert.equal(await openSTValue.registerUtilityToken.call(symbol, name, conversionRate, conversionRateDecimals, chainIdRemote, gateway.address, checkUuid, { from: registrar }), checkUuid);
   const result = await openSTValue.registerUtilityToken(symbol, name, conversionRate, conversionRateDecimals, chainIdRemote, gateway.address, checkUuid, { from: registrar });
@@ -95,7 +96,8 @@ module.exports.deployGateway = async (artifacts, accounts) => {
     gateway: gateway,
     workers: workers.address,
     bounty: bounty,
-    workerAddress1: worker1
+    workerAddress1: worker1,
+    ownerAddress: ownerAddress
   }
 };
 
@@ -161,11 +163,16 @@ module.exports.checkProcessedStakeEvent = (event, _staker, _amount) => {
   if (Number.isInteger(_amount)) {
     _amount = new BigNumber(_amount);
   }
-  console.log("event: ",event);
   assert.equal(event.event, "ProcessedStake");
   assert.equal(event.args._staker, _staker);
   assert.equal(event.args._amountST.toNumber(10), _amount.toNumber(10));
 };
 
+
+module.exports.checkWorkersSetEvent = (event, _workerAddress, _uuid) => {
+  assert.equal(event.event, "WorkersSet");
+  assert.equal(event.args._workers, _workerAddress);
+  assert.equal(event.args._uuid, _uuid);
+};
 
 

--- a/test/Gateway_utils.js
+++ b/test/Gateway_utils.js
@@ -169,10 +169,9 @@ module.exports.checkProcessedStakeEvent = (event, _staker, _amount) => {
 };
 
 
-module.exports.checkWorkersSetEvent = (event, _workerAddress, _uuid) => {
+module.exports.checkWorkersSetEvent = (event, _workersAddress) => {
   assert.equal(event.event, "WorkersSet");
-  assert.equal(event.args._workers, _workerAddress);
-  assert.equal(event.args._uuid, _uuid);
+  assert.equal(event.args._workers, _workersAddress);
 };
 
 


### PR DESCRIPTION

Implements `setWorkers` function in Gateway contract, can be only called by owner.
Includes the setWorker test case.

ref: MOSA-30
fixes: #186 