### PR TITLE
Updates comments in the SimpleToken directory [mosa-98]-I

### DIFF
--- a/contracts/SimpleToken/ERC20Interface.sol
+++ b/contracts/SimpleToken/ERC20Interface.sol
@@ -15,6 +15,11 @@ pragma solidity ^0.4.23;
 // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20-token-standard.md
 // ----------------------------------------------------------------------------
 
+/**
+ *  @title ERC20Interface which implements ERC20Interface and Owned
+ *
+ *  @notice Standard ERC20 implementation, with ownership
+ */
 contract ERC20Interface {
 
     event Transfer(address indexed _from, address indexed _to, uint256 _value);

--- a/contracts/SimpleToken/ERC20Interface.sol
+++ b/contracts/SimpleToken/ERC20Interface.sol
@@ -16,15 +16,19 @@ pragma solidity ^0.4.23;
 // ----------------------------------------------------------------------------
 
 /**
- *  @title ERC20Interface which implements ERC20Interface and Owned
+ *  @title ERC20Interface which implements ERC20Interface and Owned.
  *
- *  @notice Standard ERC20 implementation, with ownership
+ *  @notice Standard ERC20 implementation, with ownership.
  */
 contract ERC20Interface {
+
+    /** Events */
 
     event Transfer(address indexed _from, address indexed _to, uint256 _value);
     event Approval(address indexed _owner, address indexed _spender, uint256 _value);
 
+    /** Public Functions */
+    
     function name() public view returns (string);
     function symbol() public view returns (string);
     function decimals() public view returns (uint8);

--- a/contracts/SimpleToken/ERC20Token.sol
+++ b/contracts/SimpleToken/ERC20Token.sol
@@ -30,7 +30,14 @@ contract ERC20Token is ERC20Interface, Owned {
     mapping(address => uint256) balances;
     mapping(address => mapping (address => uint256)) allowed;
 
-
+    /**
+     *  @notice Contract constructor
+     *
+     *  @param _symbol symbol of the token
+     *  @param _name name of the token 
+     *  @param _decimals number of decimal places the token uses
+     *  @param _totalSupply total token supply
+     */    
     constructor(string _symbol, string _name, uint8 _decimals, uint256 _totalSupply) public
         Owned()
     {
@@ -40,50 +47,85 @@ contract ERC20Token is ERC20Interface, Owned {
         tokenTotalSupply = _totalSupply;
         balances[owner]  = _totalSupply;
 
-        /** 
-         * According to the ERC20 standard, a token contract which creates new tokens should trigger
-         * a Transfer event and transfers of 0 values must also fire the event.
-         */
+        // According to the ERC20 standard, a token contract which creates new tokens should trigger
+        // a Transfer event and transfers of 0 values must also fire the event.
         emit Transfer(0x0, owner, _totalSupply);
     }
 
-
+    /**
+     *  @notice public view function name
+     *
+     *  @return string Name of the token
+     */
     function name() public view returns (string) {
         return tokenName;
     }
 
-
+    /**
+     *  @notice public view function symbol
+     *
+     *  @return string Symbol of the token
+     */
     function symbol() public view returns (string) {
         return tokenSymbol;
     }
 
-
+    /**
+     *  @notice public view function decimals
+     *
+     *  @return uint8 number of decimals the token uses
+     */
     function decimals() public view returns (uint8) {
         return tokenDecimals;
     }
 
-
+    /**
+     *  @notice public view function totalSupply
+     *
+     *  @return uint256 Total supply of the token
+     */
     function totalSupply() public view returns (uint256) {
         return tokenTotalSupply;
     }
 
-
+    /**
+     *  @notice public view function balanceOf
+     *
+     *  @param _owner account address of the owner 
+     *
+     *  @return uint256 account balance of the owner address
+     */
     function balanceOf(address _owner) public view returns (uint256) {
         return balances[_owner];
     }
 
-
+    /**
+     *  @notice public view function allowance
+     *
+     *  @param _owner account address of the owner 
+     *  @param _spender account address of the spender
+     *
+     *  @return uint256 remaining allowance for spender to spend from owners account
+     */
     function allowance(address _owner, address _spender) public view returns (uint256 remaining) {
         return allowed[_owner][_spender];
     }
 
-
+    /**
+     *  @notice public function transfer
+     *
+     *  @dev fires the transfer event, throws if _from account does not have enough
+     *       tokens to spend.
+     *
+     *  @param _to account address to which token(s) are to be transferred  
+     *  @param _value amount value of token(s) to be transferred
+     *
+     *  @return bool true for a successful transfer, false otherwise
+     */
     function transfer(address _to, uint256 _value) public returns (bool success) {
-        /** 
-         * According to the EIP20 spec, "transfers of 0 values MUST be treated as normal
-         * transfers and fire the Transfer event".Also, should throw if not enough balance. 
-         * This is taken care of by SafeMath.
-         */
+        // According to the EIP20 spec, "transfers of 0 values MUST be treated as normal
+        // transfers and fire the Transfer event".
+        // Also, should throw if not enough balance. This is taken care of by SafeMath.
         balances[msg.sender] = balances[msg.sender].sub(_value);
         balances[_to] = balances[_to].add(_value);
 
@@ -92,7 +134,19 @@ contract ERC20Token is ERC20Interface, Owned {
         return true;
     }
 
-
+    /**
+     *  @notice public function transferFrom
+     *
+     *  @dev allows a contract to transfer tokens on behalf of _from account address to _to account address, 
+     *       the function caller has to be pre-authorized for transfers up to the total of _value amount 
+     *       by the _from account address
+     *
+     *  @param _from account address from which token(s) are to be transferred
+     *  @param _to account address to which token(s) are to be transferred  
+     *  @param _value amount value of the token(s) to be transferred
+     *
+     *  @return bool true for a successful transfer, false otherwise
+     */
     function transferFrom(address _from, address _to, uint256 _value) public returns (bool success) {
         balances[_from] = balances[_from].sub(_value);
         allowed[_from][msg.sender] = allowed[_from][msg.sender].sub(_value);
@@ -103,7 +157,15 @@ contract ERC20Token is ERC20Interface, Owned {
         return true;
     }
 
-
+    /**
+     *  @notice public function approve
+     *
+     *  @param _spender account address to be authorized to spend from the account address 
+     *         of the function caller 
+     *  @param _value amount value upto which spender is authorized to spend
+     *
+     *  @return bool true for a successful approval, false otherwise
+     */
     function approve(address _spender, uint256 _value) public returns (bool success) {
 
         allowed[msg.sender][_spender] = _value;

--- a/contracts/SimpleToken/ERC20Token.sol
+++ b/contracts/SimpleToken/ERC20Token.sol
@@ -13,10 +13,11 @@ import "./ERC20Interface.sol";
 import "./Owned.sol";
 import "./SafeMath.sol";
 
-
-//
-// Standard ERC20 implementation, with ownership.
-//
+/**
+ *  @title ERC20Token which implements ERC20Interface and Owned
+ *
+ *  @notice Standard ERC20 implementation, with ownership
+ */
 contract ERC20Token is ERC20Interface, Owned {
 
     using SafeMath for uint256;
@@ -39,8 +40,10 @@ contract ERC20Token is ERC20Interface, Owned {
         tokenTotalSupply = _totalSupply;
         balances[owner]  = _totalSupply;
 
-        // According to the ERC20 standard, a token contract which creates new tokens should trigger
-        // a Transfer event and transfers of 0 values must also fire the event.
+        /** 
+         * According to the ERC20 standard, a token contract which creates new tokens should trigger
+         * a Transfer event and transfers of 0 values must also fire the event.
+         */
         emit Transfer(0x0, owner, _totalSupply);
     }
 
@@ -76,9 +79,11 @@ contract ERC20Token is ERC20Interface, Owned {
 
 
     function transfer(address _to, uint256 _value) public returns (bool success) {
-        // According to the EIP20 spec, "transfers of 0 values MUST be treated as normal
-        // transfers and fire the Transfer event".
-        // Also, should throw if not enough balance. This is taken care of by SafeMath.
+        /** 
+         * According to the EIP20 spec, "transfers of 0 values MUST be treated as normal
+         * transfers and fire the Transfer event".Also, should throw if not enough balance. 
+         * This is taken care of by SafeMath.
+         */
         balances[msg.sender] = balances[msg.sender].sub(_value);
         balances[_to] = balances[_to].add(_value);
 

--- a/contracts/SimpleToken/ERC20Token.sol
+++ b/contracts/SimpleToken/ERC20Token.sol
@@ -14,13 +14,15 @@ import "./Owned.sol";
 import "./SafeMath.sol";
 
 /**
- *  @title ERC20Token which implements ERC20Interface and Owned
+ *  @title ERC20Token contract which implements ERC20Interface and Owned.
  *
- *  @notice Standard ERC20 implementation, with ownership
+ *  @notice Standard ERC20 implementation, with ownership.
  */
 contract ERC20Token is ERC20Interface, Owned {
 
     using SafeMath for uint256;
+
+    /** Storage */
 
     string  private tokenName;
     string  private tokenSymbol;
@@ -31,13 +33,13 @@ contract ERC20Token is ERC20Interface, Owned {
     mapping(address => mapping (address => uint256)) allowed;
 
     /**
-     *  @notice Contract constructor
+     *  @notice Contract constructor.
      *
-     *  @param _symbol symbol of the token
-     *  @param _name name of the token 
-     *  @param _decimals number of decimal places the token uses
-     *  @param _totalSupply total token supply
-     */    
+     *  @param _symbol Symbol of the token.
+     *  @param _name Name of the token.
+     *  @param _decimals Decimal places of the token.
+     *  @param _totalSupply Total supply of the token.
+     */
     constructor(string _symbol, string _name, uint8 _decimals, uint256 _totalSupply) public
         Owned()
     {
@@ -53,74 +55,74 @@ contract ERC20Token is ERC20Interface, Owned {
     }
 
     /**
-     *  @notice public view function name
+     *  @notice Public view function name.
      *
-     *  @return string Name of the token
+     *  @return string Name of the token.
      */
     function name() public view returns (string) {
         return tokenName;
     }
 
     /**
-     *  @notice public view function symbol
+     *  @notice Public view function symbol.
      *
-     *  @return string Symbol of the token
+     *  @return string Symbol of the token.
      */
     function symbol() public view returns (string) {
         return tokenSymbol;
     }
 
     /**
-     *  @notice public view function decimals
+     *  @notice Public view function decimals.
      *
-     *  @return uint8 number of decimals the token uses
+     *  @return uint8 Decimal places of the token.
      */
     function decimals() public view returns (uint8) {
         return tokenDecimals;
     }
 
     /**
-     *  @notice public view function totalSupply
+     *  @notice Public view function totalSupply.
      *
-     *  @return uint256 Total supply of the token
+     *  @return uint256 Total supply of the token.
      */
     function totalSupply() public view returns (uint256) {
         return tokenTotalSupply;
     }
 
     /**
-     *  @notice public view function balanceOf
+     *  @notice Public view function balanceOf.
      *
-     *  @param _owner account address of the owner 
+     *  @param _owner Address of the owner account.
      *
-     *  @return uint256 account balance of the owner address
+     *  @return uint256 Account balance of the owner account.
      */
     function balanceOf(address _owner) public view returns (uint256) {
         return balances[_owner];
     }
 
     /**
-     *  @notice public view function allowance
+     *  @notice Public view function allowance.
      *
-     *  @param _owner account address of the owner 
-     *  @param _spender account address of the spender
+     *  @param _owner Address of the owner account.
+     *  @param _spender Address of the spender account.
      *
-     *  @return uint256 remaining allowance for spender to spend from owners account
+     *  @return uint256 Remaining allowance for the spender to spend from owner's account.
      */
     function allowance(address _owner, address _spender) public view returns (uint256 remaining) {
         return allowed[_owner][_spender];
     }
 
     /**
-     *  @notice public function transfer
+     *  @notice Public function transfer.
      *
-     *  @dev fires the transfer event, throws if _from account does not have enough
+     *  @dev Fires the transfer event, throws if, _from account does not have enough
      *       tokens to spend.
      *
-     *  @param _to account address to which token(s) are to be transferred  
-     *  @param _value amount value of token(s) to be transferred
+     *  @param _to Address to which tokens are transferred.
+     *  @param _value Amount of tokens to be transferred.
      *
-     *  @return bool true for a successful transfer, false otherwise
+     *  @return bool True for a successful transfer, false otherwise.
      */
     function transfer(address _to, uint256 _value) public returns (bool success) {
         // According to the EIP20 spec, "transfers of 0 values MUST be treated as normal
@@ -135,17 +137,17 @@ contract ERC20Token is ERC20Interface, Owned {
     }
 
     /**
-     *  @notice public function transferFrom
+     *  @notice Public function transferFrom.
      *
-     *  @dev allows a contract to transfer tokens on behalf of _from account address to _to account address, 
-     *       the function caller has to be pre-authorized for transfers up to the total of _value amount 
-     *       by the _from account address
+     *  @dev Allows a contract to transfer tokens on behalf of _from address to _to address,
+     *       the function caller has to be pre-authorized for multiple transfers up to the 
+     *       total of _value amount by the _from address.
      *
-     *  @param _from account address from which token(s) are to be transferred
-     *  @param _to account address to which token(s) are to be transferred  
-     *  @param _value amount value of the token(s) to be transferred
+     *  @param _from Address from which tokens are transferred.
+     *  @param _to Address to which tokens are transferred.
+     *  @param _value Amount of tokens transferred.
      *
-     *  @return bool true for a successful transfer, false otherwise
+     *  @return bool True for a successful transfer, false otherwise.
      */
     function transferFrom(address _from, address _to, uint256 _value) public returns (bool success) {
         balances[_from] = balances[_from].sub(_value);
@@ -158,13 +160,16 @@ contract ERC20Token is ERC20Interface, Owned {
     }
 
     /**
-     *  @notice public function approve
+     *  @notice Public function approve.
      *
-     *  @param _spender account address to be authorized to spend from the account address 
-     *         of the function caller 
-     *  @param _value amount value upto which spender is authorized to spend
+     *  @dev Allows _spender address to withdraw from function caller's account, multiple times up 
+     *       to the _value amount, if this function is called again 
+     *       it overwrites the current allowance with _value.
      *
-     *  @return bool true for a successful approval, false otherwise
+     *  @param _spender Address authorized to spend from the function caller's address.
+     *  @param _value Amount upto which spender is authorized to spend.
+     *
+     *  @return bool True for a successful approval, false otherwise.
      */
     function approve(address _spender, uint256 _value) public returns (bool success) {
 

--- a/contracts/SimpleToken/MockToken.sol
+++ b/contracts/SimpleToken/MockToken.sol
@@ -28,7 +28,7 @@ contract MockToken is ERC20Token, OpsManaged, SimpleTokenConfig {
 
     /**
      *  @notice Contract constructor
-     * 
+     *
      *  @dev passes arguments to ERC20Token contract constructor
      */       
     constructor() public

--- a/contracts/SimpleToken/MockToken.sol
+++ b/contracts/SimpleToken/MockToken.sol
@@ -14,32 +14,36 @@ import "./SimpleTokenConfig.sol";
 import "./OpsManaged.sol";
 
 /**
- *  @title MockToken which implements ERC20Token, OpsManaged and SimpleTokenConfig
+ *  @title MockToken contract which implements ERC20Token, OpsManaged and SimpleTokenConfig.
  *
- *  @notice initializes an ERC20Token mock with arguments to facilitate testing
+ *  @notice Initializes an ERC20Token mock with arguments to facilitate testing.
  */
 contract MockToken is ERC20Token, OpsManaged, SimpleTokenConfig {
 
-    bool public finalized;
-
-    /* Events */
+    /** Events */
     
     event Finalized();
 
+    /** Storage */
+
+    bool public finalized;
+
     /**
-     *  @notice Contract constructor
+     *  @notice Contract constructor.
      *
-     *  @dev passes arguments to ERC20Token contract constructor
-     */       
+     *  @dev Inputs testing parameters to ERC20Token contract constructor.
+     */
     constructor() public
         ERC20Token("MOCK", "Mock Token", TOKEN_DECIMALS, TOKENS_MAX)
         OpsManaged()
         { }
 
     /**
-     *  @notice external function finalize
+     *  @notice External function finalize.
      *
-     *  @return bool true for finalized set to true, false otherwise
+     *  @dev Only callable by Admin.
+     *
+     *  @return bool True for finalized set to true, false otherwise.
      */
     // Finalize functionality retained because it is expected by platform scripts
     function finalize() external onlyAdmin returns (bool success) {
@@ -53,11 +57,12 @@ contract MockToken is ERC20Token, OpsManaged, SimpleTokenConfig {
     }
 
     /**
-     *  @notice public function remove
+     *  @notice Public function remove.
      *
-     *  @dev destroys the current contract, sending its funds to function caller
+     *  @dev Only callable by Owner. Destroys the current contract, 
+     *       sending its funds to function caller's address.
      */
     function remove() public onlyOwner {
         selfdestruct(msg.sender);
-    }    
+    }
 }

--- a/contracts/SimpleToken/MockToken.sol
+++ b/contracts/SimpleToken/MockToken.sol
@@ -9,17 +9,21 @@ pragma solidity ^0.4.23;
 // The MIT Licence.
 // ----------------------------------------------------------------------------
 
-
 import "./ERC20Token.sol";
 import "./SimpleTokenConfig.sol";
 import "./OpsManaged.sol";
 
+/**
+ *  @title MockToken which implements ERC20Token, OpsManaged and SimpleTokenConfig
+ *
+ *  @notice provides an ERC20Token mock to facilitate testing
+ */
 contract MockToken is ERC20Token, OpsManaged, SimpleTokenConfig {
 
     bool public finalized;
 
-
-    // Events
+    /* Events */
+    
     event Finalized();
 
     constructor() public
@@ -27,7 +31,7 @@ contract MockToken is ERC20Token, OpsManaged, SimpleTokenConfig {
         OpsManaged()
         { }
 
-    // Finalize functionality retained because it is expected by platform scripts
+    /** Finalize functionality retained because it is expected by platform scripts */
     function finalize() external onlyAdmin returns (bool success) {
         require(!finalized);
 

--- a/contracts/SimpleToken/MockToken.sol
+++ b/contracts/SimpleToken/MockToken.sol
@@ -16,7 +16,7 @@ import "./OpsManaged.sol";
 /**
  *  @title MockToken which implements ERC20Token, OpsManaged and SimpleTokenConfig
  *
- *  @notice provides an ERC20Token mock to facilitate testing
+ *  @notice initializes an ERC20Token mock with arguments to facilitate testing
  */
 contract MockToken is ERC20Token, OpsManaged, SimpleTokenConfig {
 
@@ -26,12 +26,22 @@ contract MockToken is ERC20Token, OpsManaged, SimpleTokenConfig {
     
     event Finalized();
 
+    /**
+     *  @notice Contract constructor
+     * 
+     *  @dev passes arguments to ERC20Token contract constructor
+     */       
     constructor() public
         ERC20Token("MOCK", "Mock Token", TOKEN_DECIMALS, TOKENS_MAX)
         OpsManaged()
         { }
 
-    /** Finalize functionality retained because it is expected by platform scripts */
+    /**
+     *  @notice external function finalize
+     *
+     *  @return bool true for finalized set to true, false otherwise
+     */
+    // Finalize functionality retained because it is expected by platform scripts
     function finalize() external onlyAdmin returns (bool success) {
         require(!finalized);
 
@@ -42,6 +52,11 @@ contract MockToken is ERC20Token, OpsManaged, SimpleTokenConfig {
         return true;
     }
 
+    /**
+     *  @notice public function remove
+     *
+     *  @dev destroys the current contract, sending its funds to function caller
+     */
     function remove() public onlyOwner {
         selfdestruct(msg.sender);
     }    

--- a/contracts/SimpleToken/OpsManaged.sol
+++ b/contracts/SimpleToken/OpsManaged.sol
@@ -24,9 +24,10 @@ pragma solidity ^0.4.23;
 import "./Owned.sol";
 
 /**
-   @title OpsManaged
-   @notice Implements OpenST ownership and permission model
-*/
+ *  @title OpsManaged which implements Owned
+ *
+ *  @notice Implements OpenST ownership and permission model
+ */
 contract OpsManaged is Owned {
 
     address public opsAddress;
@@ -81,7 +82,7 @@ contract OpsManaged is Owned {
     }
 
 
-    // Owner and Admin can change the admin address. Address can also be set to 0 to 'disable' it.
+    /** Owner and Admin can change the admin address. Address can also be set to 0 to 'disable' it. */
     function setAdminAddress(address _adminAddress) external onlyOwnerOrAdmin returns (bool) {
         require(_adminAddress != owner);
         require(_adminAddress != address(this));
@@ -95,7 +96,7 @@ contract OpsManaged is Owned {
     }
 
 
-    // Owner and Admin can change the operations address. Address can also be set to 0 to 'disable' it.
+    /** Owner and Admin can change the operations address. Address can also be set to 0 to 'disable' it. */
     function setOpsAddress(address _opsAddress) external onlyOwnerOrAdmin returns (bool) {
         require(_opsAddress != owner);
         require(_opsAddress != address(this));

--- a/contracts/SimpleToken/OpsManaged.sol
+++ b/contracts/SimpleToken/OpsManaged.sol
@@ -38,7 +38,7 @@ contract OpsManaged is Owned {
 
     /**
      *  @notice Contract constructor
-     * 
+     *
      *  @dev only callable by Owned
      */
     constructor() public
@@ -48,7 +48,7 @@ contract OpsManaged is Owned {
 
     /**
      *  @notice modifier onlyAdmin
-     * 
+     *
      *  @dev checks if modifier caller isAdmin
      */
     modifier onlyAdmin() {
@@ -58,7 +58,7 @@ contract OpsManaged is Owned {
 
     /**
      *  @notice modifier onlyAdminOrOps
-     * 
+     *
      *  @dev checks if modifier caller isAdmin or isOps
      */
     modifier onlyAdminOrOps() {
@@ -68,7 +68,7 @@ contract OpsManaged is Owned {
 
     /**
      *  @notice modifier onlyOwnerOrAdmin
-     * 
+     *
      *  @dev checks if modifier caller isOwner or isAdmin
      */
     modifier onlyOwnerOrAdmin() {
@@ -78,7 +78,7 @@ contract OpsManaged is Owned {
 
     /**
      *  @notice modifier onlyOps
-     * 
+     *
      *  @dev checks if modifier caller isOps
      */
     modifier onlyOps() {
@@ -88,7 +88,7 @@ contract OpsManaged is Owned {
 
     /**
      *  @notice internal view function isAdmin
-     * 
+     *
      *  @param _address address to be checked
      *
      *  @return bool true if address passed is adminAddress, false otherwise
@@ -99,7 +99,7 @@ contract OpsManaged is Owned {
 
     /**
      *  @notice internal view function isOps
-     * 
+     *
      *  @param _address address to be checked
      *
      *  @return bool true if address passed is opsAddress, false otherwise

--- a/contracts/SimpleToken/OpsManaged.sol
+++ b/contracts/SimpleToken/OpsManaged.sol
@@ -36,53 +36,98 @@ contract OpsManaged is Owned {
     event AdminAddressChanged(address indexed _newAddress);
     event OpsAddressChanged(address indexed _newAddress);
 
-
+    /**
+     *  @notice Contract constructor
+     * 
+     *  @dev only callable by Owned
+     */
     constructor() public
         Owned()
     {
     }
 
-
+    /**
+     *  @notice modifier onlyAdmin
+     * 
+     *  @dev checks if modifier caller isAdmin
+     */
     modifier onlyAdmin() {
         require(isAdmin(msg.sender));
         _;
     }
 
-
+    /**
+     *  @notice modifier onlyAdminOrOps
+     * 
+     *  @dev checks if modifier caller isAdmin or isOps
+     */
     modifier onlyAdminOrOps() {
         require(isAdmin(msg.sender) || isOps(msg.sender));
         _;
     }
 
-
+    /**
+     *  @notice modifier onlyOwnerOrAdmin
+     * 
+     *  @dev checks if modifier caller isOwner or isAdmin
+     */
     modifier onlyOwnerOrAdmin() {
         require(isOwner(msg.sender) || isAdmin(msg.sender));
         _;
     }
 
-
+    /**
+     *  @notice modifier onlyOps
+     * 
+     *  @dev checks if modifier caller isOps
+     */
     modifier onlyOps() {
         require(isOps(msg.sender));
         _;
     }
 
-
+    /**
+     *  @notice internal view function isAdmin
+     * 
+     *  @param _address address to be checked
+     *
+     *  @return bool true if address passed is adminAddress, false otherwise
+     */
     function isAdmin(address _address) internal view returns (bool) {
         return (adminAddress != address(0) && _address == adminAddress);
     }
 
-
+    /**
+     *  @notice internal view function isOps
+     * 
+     *  @param _address address to be checked
+     *
+     *  @return bool true if address passed is opsAddress, false otherwise
+     */
     function isOps(address _address) internal view returns (bool) {
         return (opsAddress != address(0) && _address == opsAddress);
     }
 
-
+    /**
+     *  @notice internal view function isOwnerOrOps
+     * 
+     *  @param _address address to be checked
+     *
+     *  @return bool true if address passed isOwner or isOps, false otherwise
+     */
     function isOwnerOrOps(address _address) internal view returns (bool) {
         return (isOwner(_address) || isOps(_address));
     }
 
-
-    /** Owner and Admin can change the admin address. Address can also be set to 0 to 'disable' it. */
+    /**
+     *  @notice external function setAdminAddress
+     * 
+     *  @dev function callable by onlyOwnerOrAdmin, address can also be set to 0 to 'disable' it
+     * 
+     *  @param _adminAddress address to be set
+     *
+     *  @return bool true if address passed is set as adminAddress, false otherwise
+     */
     function setAdminAddress(address _adminAddress) external onlyOwnerOrAdmin returns (bool) {
         require(_adminAddress != owner);
         require(_adminAddress != address(this));
@@ -95,8 +140,15 @@ contract OpsManaged is Owned {
         return true;
     }
 
-
-    /** Owner and Admin can change the operations address. Address can also be set to 0 to 'disable' it. */
+    /**
+     *  @notice external function setOpsAddress
+     * 
+     *  @dev function callable by onlyOwnerOrAdmin, address can also be set to 0 to 'disable' it
+     * 
+     *  @param _opsAddress address to be set
+     *
+     *  @return bool true if address passed is set as opsAddress, false otherwise
+     */
     function setOpsAddress(address _opsAddress) external onlyOwnerOrAdmin returns (bool) {
         require(_opsAddress != owner);
         require(_opsAddress != address(this));

--- a/contracts/SimpleToken/OpsManaged.sol
+++ b/contracts/SimpleToken/OpsManaged.sol
@@ -24,32 +24,36 @@ pragma solidity ^0.4.23;
 import "./Owned.sol";
 
 /**
- *  @title OpsManaged which implements Owned
+ *  @title OpsManaged contract which implements Owned.
  *
- *  @notice Implements OpenST ownership and permission model
+ *  @notice Implements OpenST ownership and permission model.
  */
 contract OpsManaged is Owned {
+
+    /** Events */
+    
+    event AdminAddressChanged(address indexed _newAddress);
+    event OpsAddressChanged(address indexed _newAddress);
+
+    /** Storage */
 
     address public opsAddress;
     address public adminAddress;
 
-    event AdminAddressChanged(address indexed _newAddress);
-    event OpsAddressChanged(address indexed _newAddress);
-
     /**
-     *  @notice Contract constructor
-     *
-     *  @dev only callable by Owned
+     *  @notice Contract constructor.
      */
     constructor() public
         Owned()
     {
     }
 
+    /** Modifiers */
+
     /**
-     *  @notice modifier onlyAdmin
+     *  @notice Modifier onlyAdmin.
      *
-     *  @dev checks if modifier caller isAdmin
+     *  @dev Checks if called by Admin to proceed.
      */
     modifier onlyAdmin() {
         require(isAdmin(msg.sender));
@@ -57,9 +61,9 @@ contract OpsManaged is Owned {
     }
 
     /**
-     *  @notice modifier onlyAdminOrOps
+     *  @notice Modifier onlyAdminOrOps.
      *
-     *  @dev checks if modifier caller isAdmin or isOps
+     *  @dev Checks if called by Admin or Ops to proceed.
      */
     modifier onlyAdminOrOps() {
         require(isAdmin(msg.sender) || isOps(msg.sender));
@@ -67,9 +71,9 @@ contract OpsManaged is Owned {
     }
 
     /**
-     *  @notice modifier onlyOwnerOrAdmin
+     *  @notice Modifier onlyOwnerOrAdmin.
      *
-     *  @dev checks if modifier caller isOwner or isAdmin
+     *  @dev Checks if called by Owner or Admin to proceed.
      */
     modifier onlyOwnerOrAdmin() {
         require(isOwner(msg.sender) || isAdmin(msg.sender));
@@ -77,56 +81,60 @@ contract OpsManaged is Owned {
     }
 
     /**
-     *  @notice modifier onlyOps
+     *  @notice Modifier onlyOps.
      *
-     *  @dev checks if modifier caller isOps
+     *  @dev Checks if called by Ops to proceed.
      */
     modifier onlyOps() {
         require(isOps(msg.sender));
         _;
     }
 
+    /** Internal Functions */
+
     /**
-     *  @notice internal view function isAdmin
+     *  @notice Internal view function isAdmin.
      *
-     *  @param _address address to be checked
+     *  @param _address Address to check.
      *
-     *  @return bool true if address passed is adminAddress, false otherwise
+     *  @return bool True if Admin's address, false otherwise.
      */
     function isAdmin(address _address) internal view returns (bool) {
         return (adminAddress != address(0) && _address == adminAddress);
     }
 
     /**
-     *  @notice internal view function isOps
+     *  @notice Internal view function isOps.
      *
-     *  @param _address address to be checked
+     *  @param _address Address to check.
      *
-     *  @return bool true if address passed is opsAddress, false otherwise
+     *  @return bool True if Ops's address, false otherwise.
      */
     function isOps(address _address) internal view returns (bool) {
         return (opsAddress != address(0) && _address == opsAddress);
     }
 
     /**
-     *  @notice internal view function isOwnerOrOps
+     *  @notice Internal view function isOwnerOrOps.
      * 
-     *  @param _address address to be checked
+     *  @param _address Address to check.
      *
-     *  @return bool true if address passed isOwner or isOps, false otherwise
+     *  @return bool True if Owner's or Ops address, false otherwise.
      */
     function isOwnerOrOps(address _address) internal view returns (bool) {
         return (isOwner(_address) || isOps(_address));
     }
 
+    /** External Functions */
+
     /**
-     *  @notice external function setAdminAddress
+     *  @notice External function setAdminAddress.
      * 
-     *  @dev function callable by onlyOwnerOrAdmin, address can also be set to 0 to 'disable' it
+     *  @dev Only callable by Owner or Admin, address can also be set to 0 to 'disable' it.
      * 
-     *  @param _adminAddress address to be set
+     *  @param _adminAddress Address to set.
      *
-     *  @return bool true if address passed is set as adminAddress, false otherwise
+     *  @return bool True if set as Admin's address, false otherwise.
      */
     function setAdminAddress(address _adminAddress) external onlyOwnerOrAdmin returns (bool) {
         require(_adminAddress != owner);
@@ -141,13 +149,13 @@ contract OpsManaged is Owned {
     }
 
     /**
-     *  @notice external function setOpsAddress
+     *  @notice External function setOpsAddress.
      * 
-     *  @dev function callable by onlyOwnerOrAdmin, address can also be set to 0 to 'disable' it
+     *  @dev Only callable by Owner or Admin, address can also be set to 0 to 'disable' it.
      * 
-     *  @param _opsAddress address to be set
+     *  @param _opsAddress Address to set.
      *
-     *  @return bool true if address passed is set as opsAddress, false otherwise
+     *  @return bool True if set as Ops's address, false otherwise.
      */
     function setOpsAddress(address _opsAddress) external onlyOwnerOrAdmin returns (bool) {
         require(_opsAddress != owner);

--- a/contracts/SimpleToken/Owned.sol
+++ b/contracts/SimpleToken/Owned.sol
@@ -10,56 +10,66 @@ pragma solidity ^0.4.23;
 // ----------------------------------------------------------------------------
 
 /**
- *  @title Owned contract
+ *  @title Owned contract.
  *
  *  @notice Implements basic ownership with 2-step transfers.
  */
 contract Owned {
 
-    address public owner;
-    address public proposedOwner;
-
+    /** Events */
+    
     event OwnershipTransferInitiated(address indexed _proposedOwner);
     event OwnershipTransferCompleted(address indexed _newOwner);
 
+    /** Storage */
+
+    address public owner;
+    address public proposedOwner;
+
     /**
-     *  @notice Contract constructor
+     *  @notice Contract constructor.
      *
-     *  @dev sets constructor caller to owner
+     *  @dev Sets caller to owner.
      */
     constructor() public {
         owner = msg.sender;
     }
 
+    /** Modifiers */
+
     /**
-     *  @notice modifier onlyOwner
+     *  @notice Modifier onlyOwner.
      *
-     *  @dev checks if modifier caller isOwner
+     *  @dev Checks if called by Owner to proceed.
      */
     modifier onlyOwner() {
         require(isOwner(msg.sender));
         _;
     }
 
+    /** Internal Functions */
+
     /**
-     *  @notice internal view function isOwner
+     *  @notice Internal view function isOwner.
      *
-     *  @param _address address to be checked
+     *  @param _address Address to check.
      *
-     *  @return bool true if address passed is owner address, false otherwise
+     *  @return bool True if Owner's address, false otherwise.
      */
     function isOwner(address _address) internal view returns (bool) {
         return (_address == owner);
     }
 
+    /** Public Functions */
+
     /**
-     *  @notice public function initiateOwnershipTransfer
+     *  @notice Public function initiateOwnershipTransfer.
      *
-     *  @dev sets _proposedOwner as proposedOwner
+     *  @dev Sets _proposedOwner address to proposedOwner.
      *
-     *  @param _proposedOwner address of proposed owner
+     *  @param _proposedOwner Address of new proposed owner.
      *
-     *  @return bool true if ownership transfer is successful, false otherwise
+     *  @return bool True if initiating ownership transfer is successful, false otherwise.
      */
     function initiateOwnershipTransfer(address _proposedOwner) public onlyOwner returns (bool) {
         proposedOwner = _proposedOwner;
@@ -70,12 +80,12 @@ contract Owned {
     }
 
     /**
-     *  @notice public function completeOwnershipTransfer
+     *  @notice Public function completeOwnershipTransfer.
      *
-     *  @dev only callable by proposedOwner, sets function caller as Owner 
+     *  @dev Only callable by proposed Owner, sets caller to Owner 
      *       and proposedOwner to 0 address.
      *
-     *  @return bool true if complete ownership transfer is successful, false otherwise
+     *  @return bool True if complete ownership transfer is successful, false otherwise.
      */
     function completeOwnershipTransfer() public returns (bool) {
         require(msg.sender == proposedOwner);

--- a/contracts/SimpleToken/Owned.sol
+++ b/contracts/SimpleToken/Owned.sol
@@ -10,9 +10,9 @@ pragma solidity ^0.4.23;
 // ----------------------------------------------------------------------------
 
 /**
- *  @title Owned contract 
+ *  @title Owned contract
  *
- *  @notice Implements basic ownership with 2-step transfers
+ *  @notice Implements basic ownership with 2-step transfers.
  */
 contract Owned {
 
@@ -22,23 +22,45 @@ contract Owned {
     event OwnershipTransferInitiated(address indexed _proposedOwner);
     event OwnershipTransferCompleted(address indexed _newOwner);
 
-
+    /**
+     *  @notice Contract constructor
+     *
+     *  @dev sets constructor caller to owner
+     */
     constructor() public {
         owner = msg.sender;
     }
 
-
+    /**
+     *  @notice modifier onlyOwner
+     * 
+     *  @dev checks if modifier caller isOwner
+     */
     modifier onlyOwner() {
         require(isOwner(msg.sender));
         _;
     }
 
-
+    /**
+     *  @notice internal view function isOwner
+     * 
+     *  @param _address address to be checked
+     *
+     *  @return bool true if address passed is owner address, false otherwise
+     */
     function isOwner(address _address) internal view returns (bool) {
         return (_address == owner);
     }
 
-
+    /**
+     *  @notice public function initiateOwnershipTransfer
+     * 
+     *  @dev sets _proposedOwner as proposedOwner
+     *
+     *  @param _proposedOwner address of proposed owner
+     *
+     *  @return bool true if ownership transfer is successful, false otherwise
+     */
     function initiateOwnershipTransfer(address _proposedOwner) public onlyOwner returns (bool) {
         proposedOwner = _proposedOwner;
 
@@ -47,7 +69,14 @@ contract Owned {
         return true;
     }
 
-
+    /**
+     *  @notice public function completeOwnershipTransfer
+     * 
+     *  @dev only callable by proposedOwner, sets function caller as Owner 
+     *       and proposedOwner to 0 address.
+     *
+     *  @return bool true if complete ownership transfer is successful, false otherwise
+     */
     function completeOwnershipTransfer() public returns (bool) {
         require(msg.sender == proposedOwner);
 

--- a/contracts/SimpleToken/Owned.sol
+++ b/contracts/SimpleToken/Owned.sol
@@ -33,7 +33,7 @@ contract Owned {
 
     /**
      *  @notice modifier onlyOwner
-     * 
+     *
      *  @dev checks if modifier caller isOwner
      */
     modifier onlyOwner() {
@@ -43,7 +43,7 @@ contract Owned {
 
     /**
      *  @notice internal view function isOwner
-     * 
+     *
      *  @param _address address to be checked
      *
      *  @return bool true if address passed is owner address, false otherwise
@@ -54,7 +54,7 @@ contract Owned {
 
     /**
      *  @notice public function initiateOwnershipTransfer
-     * 
+     *
      *  @dev sets _proposedOwner as proposedOwner
      *
      *  @param _proposedOwner address of proposed owner
@@ -71,7 +71,7 @@ contract Owned {
 
     /**
      *  @notice public function completeOwnershipTransfer
-     * 
+     *
      *  @dev only callable by proposedOwner, sets function caller as Owner 
      *       and proposedOwner to 0 address.
      *

--- a/contracts/SimpleToken/Owned.sol
+++ b/contracts/SimpleToken/Owned.sol
@@ -9,10 +9,11 @@ pragma solidity ^0.4.23;
 // The MIT Licence.
 // ----------------------------------------------------------------------------
 
-
-//
-// Implements basic ownership with 2-step transfers.
-//
+/**
+ *  @title Owned contract 
+ *
+ *  @notice Implements basic ownership with 2-step transfers
+ */
 contract Owned {
 
     address public owner;

--- a/contracts/SimpleToken/SafeMath.sol
+++ b/contracts/SimpleToken/SafeMath.sol
@@ -21,6 +21,14 @@ pragma solidity ^0.4.23;
  */
 library SafeMath {
 
+    /**
+     *  @notice internal pure function mul
+     * 
+     *  @param a unsigned integer multiplicand
+     *  @param b unsigned integer multiplier
+     *
+     *  @return uint256 product
+     */
     function mul(uint256 a, uint256 b) internal pure returns (uint256) {
         uint256 c = a * b;
 
@@ -29,23 +37,44 @@ library SafeMath {
         return c;
     }
 
-
+    /**
+     *  @notice internal pure function div
+     * 
+     *  @param a unsigned integer dividend
+     *  @param b unsigned integer divisor
+     *
+     *  @return uint256 quotient
+     */
     function div(uint256 a, uint256 b) internal pure returns (uint256) {
-        /** Solidity automatically throws when dividing by 0 */
+        // Solidity automatically throws when dividing by 0 
         uint256 c = a / b;
 
-        /** assert(a == b * c + a % b); There is no case in which this doesn't hold */
+        // assert(a == b * c + a % b); There is no case in which this doesn't hold
         return c;
     }
 
-
+    /**
+     *  @notice internal pure function sub
+     * 
+     *  @param a unsigned integer minuend
+     *  @param b unsigned integer subtrahend 
+     *
+     *  @return uint256 difference
+     */
     function sub(uint256 a, uint256 b) internal pure returns (uint256) {
         assert(b <= a);
 
         return a - b;
     }
 
-
+    /**
+     *  @notice internal pure function add
+     * 
+     *  @param a unsigned integer augend
+     *  @param b unsigned integer addend
+     *
+     *  @return uint256 sum
+     */
     function add(uint256 a, uint256 b) internal pure returns (uint256) {
         uint256 c = a + b;
 

--- a/contracts/SimpleToken/SafeMath.sol
+++ b/contracts/SimpleToken/SafeMath.sol
@@ -14,7 +14,11 @@ pragma solidity ^0.4.23;
 // The MIT License.
 // ----------------------------------------------------------------------------
 
-
+/**
+ *  @title Safemath library
+ *
+ *  @notice Based on the SafeMath library by the OpenZeppelin team.
+ */
 library SafeMath {
 
     function mul(uint256 a, uint256 b) internal pure returns (uint256) {
@@ -27,10 +31,10 @@ library SafeMath {
 
 
     function div(uint256 a, uint256 b) internal pure returns (uint256) {
-        // Solidity automatically throws when dividing by 0
+        /** Solidity automatically throws when dividing by 0 */
         uint256 c = a / b;
 
-        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+        /** assert(a == b * c + a % b); There is no case in which this doesn't hold */
         return c;
     }
 

--- a/contracts/SimpleToken/SafeMath.sol
+++ b/contracts/SimpleToken/SafeMath.sol
@@ -15,19 +15,21 @@ pragma solidity ^0.4.23;
 // ----------------------------------------------------------------------------
 
 /**
- *  @title Safemath library
+ *  @title Safemath library.
  *
  *  @notice Based on the SafeMath library by the OpenZeppelin team.
  */
 library SafeMath {
 
+    /** Internal Functions */
+
     /**
-     *  @notice internal pure function mul
+     *  @notice Internal pure function mul.
      *
-     *  @param a unsigned integer multiplicand
-     *  @param b unsigned integer multiplier
+     *  @param a Unsigned integer multiplicand.
+     *  @param b Unsigned integer multiplier.
      *
-     *  @return uint256 product
+     *  @return uint256 Product.
      */
     function mul(uint256 a, uint256 b) internal pure returns (uint256) {
         uint256 c = a * b;
@@ -38,12 +40,12 @@ library SafeMath {
     }
 
     /**
-     *  @notice internal pure function div
+     *  @notice Internal pure function div.
      *
-     *  @param a unsigned integer dividend
-     *  @param b unsigned integer divisor
+     *  @param a Unsigned integer dividend.
+     *  @param b Unsigned integer divisor.
      *
-     *  @return uint256 quotient
+     *  @return uint256 Quotient.
      */
     function div(uint256 a, uint256 b) internal pure returns (uint256) {
         // Solidity automatically throws when dividing by 0 
@@ -54,12 +56,12 @@ library SafeMath {
     }
 
     /**
-     *  @notice internal pure function sub
+     *  @notice Internal pure function sub.
      *
-     *  @param a unsigned integer minuend
-     *  @param b unsigned integer subtrahend 
+     *  @param a Unsigned integer minuend.
+     *  @param b Unsigned integer subtrahend.
      *
-     *  @return uint256 difference
+     *  @return uint256 Difference.
      */
     function sub(uint256 a, uint256 b) internal pure returns (uint256) {
         assert(b <= a);
@@ -68,12 +70,12 @@ library SafeMath {
     }
 
     /**
-     *  @notice internal pure function add
+     *  @notice Internal pure function add.
      *
-     *  @param a unsigned integer augend
-     *  @param b unsigned integer addend
+     *  @param a Unsigned integer augend.
+     *  @param b Unsigned integer addend.
      *
-     *  @return uint256 sum
+     *  @return uint256 Sum.
      */
     function add(uint256 a, uint256 b) internal pure returns (uint256) {
         uint256 c = a + b;

--- a/contracts/SimpleToken/SafeMath.sol
+++ b/contracts/SimpleToken/SafeMath.sol
@@ -23,7 +23,7 @@ library SafeMath {
 
     /**
      *  @notice internal pure function mul
-     * 
+     *
      *  @param a unsigned integer multiplicand
      *  @param b unsigned integer multiplier
      *
@@ -39,7 +39,7 @@ library SafeMath {
 
     /**
      *  @notice internal pure function div
-     * 
+     *
      *  @param a unsigned integer dividend
      *  @param b unsigned integer divisor
      *
@@ -55,7 +55,7 @@ library SafeMath {
 
     /**
      *  @notice internal pure function sub
-     * 
+     *
      *  @param a unsigned integer minuend
      *  @param b unsigned integer subtrahend 
      *
@@ -69,7 +69,7 @@ library SafeMath {
 
     /**
      *  @notice internal pure function add
-     * 
+     *
      *  @param a unsigned integer augend
      *  @param b unsigned integer addend
      *

--- a/contracts/SimpleToken/SimpleToken.sol
+++ b/contracts/SimpleToken/SimpleToken.sol
@@ -34,23 +34,25 @@ import "./OpsManaged.sol";
 //
 
 /**
- *  @title SimpleToken which implements ERC20Token, OpsManaged, SimpleTokenConfig
+ *  @title SimpleToken contract which implements ERC20Token, OpsManaged, SimpleTokenConfig.
  *
- *  @notice Implments ERC20Token with added functionality
+ *  @notice Implments ERC20Token with added functionality.
  */
 contract SimpleToken is ERC20Token, OpsManaged, SimpleTokenConfig {
 
-    bool public finalized;
+    /** Events */
 
-
-    // Events
     event Burnt(address indexed _from, uint256 _amount);
     event Finalized();
 
+    /** Storage */
+    
+    bool public finalized;
+
     /**
-     *  @notice Contract constructor
-     * 
-     *  @dev only callable by OpsManaged
+     *  @notice Contract constructor.
+     *
+     *  @dev Sets finalized to false.
      */
     constructor() public
         ERC20Token(TOKEN_SYMBOL, TOKEN_NAME, TOKEN_DECIMALS, TOKENS_MAX)
@@ -59,23 +61,52 @@ contract SimpleToken is ERC20Token, OpsManaged, SimpleTokenConfig {
         finalized = false;
     }
 
-
-    // Implementation of the standard transfer method that takes into account the finalize flag.
+    /**
+     *  @notice Public function transfer.
+     *
+     *  @dev Fires the transfer event, throws if, _from account does not have enough
+     *       tokens to spend. Implementation of the standard transfer method that takes 
+     *       into account the finalize flag.
+     *
+     *  @param _to Address to which tokens are transferred.
+     *  @param _value Amount of tokens to be transferred.
+     *
+     *  @return bool True for a successful transfer, false otherwise.
+     */
     function transfer(address _to, uint256 _value) public returns (bool success) {
         checkTransferAllowed(msg.sender, _to);
 
         return super.transfer(_to, _value);
     }
 
-
-    // Implementation of the standard transferFrom method that takes into account the finalize flag.
+    /**
+     *  @notice Public function transferFrom.
+     *
+     *  @dev Allows a contract to transfer tokens on behalf of _from address to _to address,
+     *       the function caller has to be pre-authorized for multiple transfers up to the 
+     *       total of _value amount by the _from address. Implementation of the standard 
+     *       transferFrom method that takes into account the finalize flag.
+     *
+     *  @param _from Address from which tokens are transferred.
+     *  @param _to Address to which tokens are transferred.
+     *  @param _value Amount of tokens transferred.
+     *
+     *  @return bool True for a successful transfer, false otherwise.
+     */
     function transferFrom(address _from, address _to, uint256 _value) public returns (bool success) {
         checkTransferAllowed(msg.sender, _to);
 
         return super.transferFrom(_from, _to, _value);
     }
 
-
+    /**
+     *  @notice Private view function checkTransferAllowed.
+     *
+     *  @dev Checks if _sender address is Owner or Ops, or if _to address is Owner, throws otherwise.
+     *
+     *  @param _sender Address of the sender.
+     *  @param _to Address to check, if transfer is allowed to.
+     */
     function checkTransferAllowed(address _sender, address _to) private view {
         if (finalized) {
             // Everybody should be ok to transfer once the token is finalized.
@@ -89,8 +120,16 @@ contract SimpleToken is ERC20Token, OpsManaged, SimpleTokenConfig {
         require(isOwnerOrOps(_sender) || _to == owner);
     }
 
-    // Implement a burn function to permit msg.sender to reduce its balance
-    // which also reduces tokenTotalSupply
+    /**
+     *  @notice Public function burn.
+     *
+     *  @dev Implements a burn function to permit msg.sender to reduce its balance,
+     *       which also reduces tokenTotalSupply.
+     *
+     *  @param _value Amount of tokens to burn.
+     *
+     *  @return True if burn is successful, false otherwise.
+     */
     function burn(uint256 _value) public returns (bool success) {
         require(_value <= balances[msg.sender]);
 
@@ -102,8 +141,14 @@ contract SimpleToken is ERC20Token, OpsManaged, SimpleTokenConfig {
         return true;
     }
 
-
-    // Finalize method marks the point where token transfers are finally allowed for everybody.
+    /**
+     *  @notice External function onlyAdmin.
+     *
+     *  @dev Only callable by Admin. Finalize method marks the point where 
+     *       token transfers are finally allowed for everybody.
+     *
+     *  @return True if finalized is set to true, false otherwise.
+     */    
     function finalize() external onlyAdmin returns (bool success) {
         require(!finalized);
 

--- a/contracts/SimpleToken/SimpleToken.sol
+++ b/contracts/SimpleToken/SimpleToken.sol
@@ -9,36 +9,35 @@ pragma solidity ^0.4.23;
 // The MIT Licence.
 // ----------------------------------------------------------------------------
 
-
 import "./ERC20Token.sol";
 import "./SimpleTokenConfig.sol";
 import "./OpsManaged.sol";
 
+/**
+ *  @title SimpleToken contract which implements ERC20Token, OpsManaged and SimpleTokenConfig
+ *
+ *  @notice SimpleToken is a standard ERC20 token with some additional functionality:
+ *  It has a concept of finalize
+ *  Before finalize, nobody can transfer tokens except:
+ *     Owner and operations can transfer tokens
+ *     Anybody can send back tokens to owner
+ *  After finalize, no restrictions on token transfers
+ */
 
-//
-// SimpleToken is a standard ERC20 token with some additional functionality:
-// - It has a concept of finalize
-// - Before finalize, nobody can transfer tokens except:
-//     - Owner and operations can transfer tokens
-//     - Anybody can send back tokens to owner
-// - After finalize, no restrictions on token transfers
-//
-
-//
-// Permissions, according to the ST key management specification.
-//
-//                                    Owner    Admin   Ops
-// transfer (before finalize)           x               x
-// transferForm (before finalize)       x               x
-// finalize                                      x
-//
-
+/**
+ * Permissions, according to the ST key management specification.
+ *
+ *                                    Owner    Admin   Ops
+ * transfer (before finalize)           x               x
+ * transferForm (before finalize)       x               x
+ * finalize                                      x
+ */
 contract SimpleToken is ERC20Token, OpsManaged, SimpleTokenConfig {
 
     bool public finalized;
 
 
-    // Events
+    /* Events */
     event Burnt(address indexed _from, uint256 _amount);
     event Finalized();
 
@@ -51,7 +50,7 @@ contract SimpleToken is ERC20Token, OpsManaged, SimpleTokenConfig {
     }
 
 
-    // Implementation of the standard transfer method that takes into account the finalize flag.
+    /** Implementation of the standard transfer method that takes into account the finalize flag. */
     function transfer(address _to, uint256 _value) public returns (bool success) {
         checkTransferAllowed(msg.sender, _to);
 
@@ -59,7 +58,7 @@ contract SimpleToken is ERC20Token, OpsManaged, SimpleTokenConfig {
     }
 
 
-    // Implementation of the standard transferFrom method that takes into account the finalize flag.
+    /** Implementation of the standard transferFrom method that takes into account the finalize flag. */
     function transferFrom(address _from, address _to, uint256 _value) public returns (bool success) {
         checkTransferAllowed(msg.sender, _to);
 
@@ -69,19 +68,23 @@ contract SimpleToken is ERC20Token, OpsManaged, SimpleTokenConfig {
 
     function checkTransferAllowed(address _sender, address _to) private view {
         if (finalized) {
-            // Everybody should be ok to transfer once the token is finalized.
+            /** Everybody should be ok to transfer once the token is finalized. */
             return;
         }
 
-        // Owner and Ops are allowed to transfer tokens before the sale is finalized.
-        // This allows the tokens to move from the TokenSale contract to a beneficiary.
-        // We also allow someone to send tokens back to the owner. This is useful among other
-        // cases, for the Trustee to transfer unlocked tokens back to the owner (reclaimTokens).
+        /**
+         * Owner and Ops are allowed to transfer tokens before the sale is finalized.
+         * This allows the tokens to move from the TokenSale contract to a beneficiary.
+         * We also allow someone to send tokens back to the owner. This is useful among other
+         * cases, for the Trustee to transfer unlocked tokens back to the owner (reclaimTokens).
+         */
         require(isOwnerOrOps(_sender) || _to == owner);
     }
 
-    // Implement a burn function to permit msg.sender to reduce its balance
-    // which also reduces tokenTotalSupply
+    /**
+     * Implement a burn function to permit msg.sender to reduce its balance
+     * which also reduces tokenTotalSupply
+     */
     function burn(uint256 _value) public returns (bool success) {
         require(_value <= balances[msg.sender]);
 
@@ -94,7 +97,7 @@ contract SimpleToken is ERC20Token, OpsManaged, SimpleTokenConfig {
     }
 
 
-    // Finalize method marks the point where token transfers are finally allowed for everybody.
+    /** Finalize method marks the point where token transfers are finally allowed for everybody. */
     function finalize() external onlyAdmin returns (bool success) {
         require(!finalized);
 

--- a/contracts/SimpleToken/SimpleToken.sol
+++ b/contracts/SimpleToken/SimpleToken.sol
@@ -9,39 +9,49 @@ pragma solidity ^0.4.23;
 // The MIT Licence.
 // ----------------------------------------------------------------------------
 
+
 import "./ERC20Token.sol";
 import "./SimpleTokenConfig.sol";
 import "./OpsManaged.sol";
 
-/**
- *  @title SimpleToken contract which implements ERC20Token, OpsManaged and SimpleTokenConfig
- *
- *  @notice SimpleToken is a standard ERC20 token with some additional functionality:
- *  It has a concept of finalize
- *  Before finalize, nobody can transfer tokens except:
- *     Owner and operations can transfer tokens
- *     Anybody can send back tokens to owner
- *  After finalize, no restrictions on token transfers
- */
+
+//
+// SimpleToken is a standard ERC20 token with some additional functionality:
+// - It has a concept of finalize
+// - Before finalize, nobody can transfer tokens except:
+//     - Owner and operations can transfer tokens
+//     - Anybody can send back tokens to owner
+// - After finalize, no restrictions on token transfers
+//
+
+//
+// Permissions, according to the ST key management specification.
+//
+//                                    Owner    Admin   Ops
+// transfer (before finalize)           x               x
+// transferForm (before finalize)       x               x
+// finalize                                      x
+//
 
 /**
- * Permissions, according to the ST key management specification.
+ *  @title SimpleToken which implements ERC20Token, OpsManaged, SimpleTokenConfig
  *
- *                                    Owner    Admin   Ops
- * transfer (before finalize)           x               x
- * transferForm (before finalize)       x               x
- * finalize                                      x
+ *  @notice Implments ERC20Token with added functionality
  */
 contract SimpleToken is ERC20Token, OpsManaged, SimpleTokenConfig {
 
     bool public finalized;
 
 
-    /* Events */
+    // Events
     event Burnt(address indexed _from, uint256 _amount);
     event Finalized();
 
-
+    /**
+     *  @notice Contract constructor
+     * 
+     *  @dev only callable by OpsManaged
+     */
     constructor() public
         ERC20Token(TOKEN_SYMBOL, TOKEN_NAME, TOKEN_DECIMALS, TOKENS_MAX)
         OpsManaged()
@@ -50,7 +60,7 @@ contract SimpleToken is ERC20Token, OpsManaged, SimpleTokenConfig {
     }
 
 
-    /** Implementation of the standard transfer method that takes into account the finalize flag. */
+    // Implementation of the standard transfer method that takes into account the finalize flag.
     function transfer(address _to, uint256 _value) public returns (bool success) {
         checkTransferAllowed(msg.sender, _to);
 
@@ -58,7 +68,7 @@ contract SimpleToken is ERC20Token, OpsManaged, SimpleTokenConfig {
     }
 
 
-    /** Implementation of the standard transferFrom method that takes into account the finalize flag. */
+    // Implementation of the standard transferFrom method that takes into account the finalize flag.
     function transferFrom(address _from, address _to, uint256 _value) public returns (bool success) {
         checkTransferAllowed(msg.sender, _to);
 
@@ -68,23 +78,19 @@ contract SimpleToken is ERC20Token, OpsManaged, SimpleTokenConfig {
 
     function checkTransferAllowed(address _sender, address _to) private view {
         if (finalized) {
-            /** Everybody should be ok to transfer once the token is finalized. */
+            // Everybody should be ok to transfer once the token is finalized.
             return;
         }
 
-        /**
-         * Owner and Ops are allowed to transfer tokens before the sale is finalized.
-         * This allows the tokens to move from the TokenSale contract to a beneficiary.
-         * We also allow someone to send tokens back to the owner. This is useful among other
-         * cases, for the Trustee to transfer unlocked tokens back to the owner (reclaimTokens).
-         */
+        // Owner and Ops are allowed to transfer tokens before the sale is finalized.
+        // This allows the tokens to move from the TokenSale contract to a beneficiary.
+        // We also allow someone to send tokens back to the owner. This is useful among other
+        // cases, for the Trustee to transfer unlocked tokens back to the owner (reclaimTokens).
         require(isOwnerOrOps(_sender) || _to == owner);
     }
 
-    /**
-     * Implement a burn function to permit msg.sender to reduce its balance
-     * which also reduces tokenTotalSupply
-     */
+    // Implement a burn function to permit msg.sender to reduce its balance
+    // which also reduces tokenTotalSupply
     function burn(uint256 _value) public returns (bool success) {
         require(_value <= balances[msg.sender]);
 
@@ -97,7 +103,7 @@ contract SimpleToken is ERC20Token, OpsManaged, SimpleTokenConfig {
     }
 
 
-    /** Finalize method marks the point where token transfers are finally allowed for everybody. */
+    // Finalize method marks the point where token transfers are finally allowed for everybody.
     function finalize() external onlyAdmin returns (bool success) {
         require(!finalized);
 

--- a/contracts/SimpleToken/SimpleTokenConfig.sol
+++ b/contracts/SimpleToken/SimpleTokenConfig.sol
@@ -9,7 +9,11 @@ pragma solidity ^0.4.23;
 // The MIT Licence.
 // ----------------------------------------------------------------------------
 
-
+/**
+ *  @title SimpleTokenConfig
+ *
+ *  @notice Contains public constants utilized by the SimpleToken contract
+ */
 contract SimpleTokenConfig {
 
     string  public constant TOKEN_SYMBOL   = "ST";

--- a/contracts/SimpleToken/SimpleTokenConfig.sol
+++ b/contracts/SimpleToken/SimpleTokenConfig.sol
@@ -10,12 +10,14 @@ pragma solidity ^0.4.23;
 // ----------------------------------------------------------------------------
 
 /**
- *  @title SimpleTokenConfig
+ *  @title SimpleTokenConfig contract.
  *
- *  @notice Contains public constants utilized by the SimpleToken contract
+ *  @notice Contains public constants utilized by the SimpleToken contract.
  */
 contract SimpleTokenConfig {
 
+	/** Constants */
+	
     string  public constant TOKEN_SYMBOL   = "ST";
     string  public constant TOKEN_NAME     = "Simple Token";
     uint8   public constant TOKEN_DECIMALS = 18;


### PR DESCRIPTION
* Replaces `///` document comment style with `/** */` one.
* One-liner doc comments follow the same guideline: /** */ -  for struct, enum and member vars.
* For multiline doc comments, it should be
`/**`
   `*  @title A title that should describe the contract or interface.`
   `*`
   `*  @notice Explain to a user what a contract, interface or function does.`
   `*`
   `*  @dev Explain to a developer any extra details for a contract, interface or function.`
   `*`
   `*  @param _firstParameterName Documents a parameter of a function`
   `*`              `just like in doxygen.`
   `*  @param _secondParamName Followed by second param details.`
   `*`
   `*  @return type Documents the return type of a contract's function.`
   `*/`
* All comment lines start with caps and end with a period, using proper grammar. 