### PR TITLE
GitHub Syntax Highlighting for Solidity

### DIFF
--- a/.gitattribute
+++ b/.gitattribute
@@ -1,0 +1,1 @@
+*.sol linguist-language=Solidity


### PR DESCRIPTION
GitHub uses linguist to enable language-related features. According to
linguist’s maintainers, the .sol file extension is too generic to assign
to Solidity.

As a solution the mapping is added to the `.gitattribute` file.

According to
https://medium.com/@danielque/psa-how-to-fix-githubs-syntax-highlighting-for-solidity-4e9867c540b6

Fixes #214