### PR TITLE
Added docs specification for structs and maps

### DIFF
--- a/SOLIDITY_STYLE_GUIDE.md
+++ b/SOLIDITY_STYLE_GUIDE.md
@@ -172,6 +172,38 @@ contract A {
 }
 ```
 
+Within a struct, surround documented field declarations with a *single* blank
+line.
+
+`Example`
+
+```solidity
+/**
+ * Message stores the message content as well as additional data about the
+ * sender and the receiver. This way, it can be verified that the message has
+ * not been manipulated.
+ */
+struct Message {
+    /**
+     * The message content bytes encoded.
+     * The string encoding must be UTF-8.
+     */
+    bytes32 message;
+
+    /** Address where the message should be sent to. */
+    address receiver;
+
+    /** Address of the account that created this message. */
+    address sender;
+
+    /**
+     * The signature is created by the sender and is the signed hash of the
+     * message: sha3(message, receiver, sender).
+     */
+    bytes32 signature;
+}
+```
+
 Section declarations should follow with a single blank line:
 
 `Good`
@@ -1407,13 +1439,13 @@ struct Message {
      * The string encoding must be UTF-8.
      */
     bytes32 message;
-    
+
     /** Address where the message should be sent to. */
     address receiver;
-    
+
     /** Address of the account that created this message. */
     address sender;
-    
+
     /**
      * The signature is created by the sender and is the signed hash of the
      * message: sha3(message, receiver, sender).

--- a/SOLIDITY_STYLE_GUIDE.md
+++ b/SOLIDITY_STYLE_GUIDE.md
@@ -36,7 +36,7 @@
   4. [Documentation](#documentation)
         1. [Single Line](#single-line)
         2. [Multi Line](#multi-line)
-        3. [Structs and Maps](#structs-and-maps)
+        3. [Structs and Mappings](#structs-and-mappings)
         4. [Spaces](#spaces)
         5. [English Sentence](#english-sentence)
         6. [Grouping](#grouping)
@@ -1379,9 +1379,10 @@ function getStorageRoot(uint256 _blockHeight)
 }
 ```
 
-### Structs and Maps
+### Structs and Mappings
 
-Document structs above the struct and struct fields above the respective field.
+Document structs above the struct declaration
+Document struct fields above the respective field.
 
 `Good`
 
@@ -1390,8 +1391,34 @@ Document structs above the struct and struct fields above the respective field.
 struct Bank {
     /** The owner of the bank functions simultaniously as the owner of the funds in balance. */
     address owner;
+
     /** The balance of the owner in Ethereum Wei. */
     uint256 balance;
+}
+
+/**
+ * Message stores the message content as well as additional data about the
+ * sender and the receiver. This way, it can be verified that the message has
+ * not been manipulated.
+ */
+struct Message {
+    /**
+     * The message content bytes encoded.
+     * The string encoding must be UTF-8.
+     */
+    bytes32 message;
+    
+    /** Address where the message should be sent to. */
+    address receiver;
+    
+    /** Address of the account that created this message. */
+    address sender;
+    
+    /**
+     * The signature is created by the sender and is the signed hash of the
+     * message: sha3(message, receiver, sender).
+     */
+    bytes32 signature;
 }
 ```
 
@@ -1405,7 +1432,7 @@ struct Bank {
 }
 ```
 
-Document mappings above the mapping.
+Document mappings above the mappings' respective declaration.
 
 `Good`
 

--- a/SOLIDITY_STYLE_GUIDE.md
+++ b/SOLIDITY_STYLE_GUIDE.md
@@ -36,10 +36,11 @@
   4. [Documentation](#documentation)
         1. [Single Line](#single-line)
         2. [Multi Line](#multi-line)
-        3. [Spaces](#spaces)
-        4. [English Sentence](#english-sentence)
-        5. [Grouping](#grouping)
-        6. [Alignment](#alignment)
+        3. [Structs and Maps](#structs-and-maps)
+        4. [Spaces](#spaces)
+        5. [English Sentence](#english-sentence)
+        6. [Grouping](#grouping)
+        7. [Alignment](#alignment)
   5. [Comments](#comments)
 
 *The current style guide is mostly based on [Ethereum Solidity Style Guide](http://solidity.readthedocs.io/en/v0.4.24/style-guide.html)
@@ -1376,6 +1377,48 @@ function getStorageRoot(uint256 _blockHeight)
 {
     ...
 }
+```
+
+### Structs and Maps
+
+Document structs above the struct and struct fields above the respective field.
+
+`Good`
+
+```solidity
+/** A Bank has a single owner. You need to create one bank per person. */
+struct Bank {
+    /** The owner of the bank functions simultaniously as the owner of the funds in balance. */
+    address owner;
+    /** The balance of the owner in Ethereum Wei. */
+    uint256 balance;
+}
+```
+
+`Bad`
+
+```solidity
+/** A Bank has a single owner. You need to create one bank per person. */
+struct Bank {
+    address owner; /** The owner of the bank functions simultaniously as the owner of the funds in balance. */
+    uint256 balance; // The balance of the owner in Ethereum Wei.
+}
+```
+
+Document mappings above the mapping.
+
+`Good`
+
+```solidity
+/** balances stores per address the total balance in SimpleToken Wei. */
+mapping (address => uint) public balances;
+```
+
+`Bad`
+
+```solidity
+mapping (address => uint) public balances; /** balances stores per address the total balance in SimpleToken Wei. */
+mapping (address => uint) public balances; // balances stores per address the total balance in SimpleToken Wei.
 ```
 
 ### Spaces

--- a/SOLIDITY_STYLE_GUIDE.md
+++ b/SOLIDITY_STYLE_GUIDE.md
@@ -1381,7 +1381,7 @@ function getStorageRoot(uint256 _blockHeight)
 
 ### Structs and Mappings
 
-Document structs above the struct declaration
+Document structs above the struct declaration.
 Document struct fields above the respective field.
 
 `Good`


### PR DESCRIPTION
The solidity style guide now includes instructions on how to document
structs and mappings. Othere Solidity projects seem to not do this, so
it was not possible to adhere to a community standard.
Instead, I compared how rust and golang recommend to do it and chose the
rust way of documenting structs and mappings.

In golang, a struct's field would be documented on the same line after
the name.

I used `/** */` instead of `///` as our style guide explicitly says to
avoid `///`.