### PR TITLE
Indentation of @return multiline is now correct

### DIFF
--- a/SOLIDITY_STYLE_GUIDE.md
+++ b/SOLIDITY_STYLE_GUIDE.md
@@ -1400,7 +1400,7 @@ Multi line documentation format is:
  * @param _blockHeight Block height to return storage root.
  *
  * @return bytes32(0) if a storage root for specified block height was not
- *          verified otherwise saved storage root.
+ *         verified otherwise saved storage root.
  */
 function getStorageRoot(uint256 _blockHeight)
     public


### PR DESCRIPTION
`@return` indentation should equal that of `@param`.

Fixes #236