### PR TITLE
Added an M-Contract to register chains

### DIFF
--- a/contracts/core/Mosaic.sol
+++ b/contracts/core/Mosaic.sol
@@ -90,7 +90,11 @@ contract Mosaic {
         external
         returns (uint256 chainId_)
     {
-        // TODO: should the contract require that a core contract exists at the given address?
+        require(
+            _coreAddress != address(0),
+            "The provided address should not be 0."
+        );
+
         chainId_ = nextChainId;
         nextChainId++;
 

--- a/contracts/core/Mosaic.sol
+++ b/contracts/core/Mosaic.sol
@@ -1,0 +1,101 @@
+pragma solidity ^0.4.23;
+// Copyright 2018 OpenST Ltd.
+
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ----------------------------------------------------------------------------
+// Value chain: Mosaic
+//
+// http://www.simpletoken.org/
+//
+// ----------------------------------------------------------------------------
+
+/**
+ * @title Mosaic tracks core contracts and validator stakes.
+ *
+ * @notice You can register other chains in this contract and it will manage
+ *         the chain ids for you.
+ *         Potential validators can use this contract to deposit and withdraw
+ *         stake for any given chain.
+ */
+contract Mosaic {
+
+    /* Events */
+
+    /** ChainRegistered is emitted when a new chain is registered. */
+    event ChainRegistered(uint256 chainId, address coreAddress);
+
+    /* Public Variables */
+
+    /**
+     * The id of the first chain that is registered. If
+     * `firstChainId == nextChainId`, then no chain has been registered yet.
+     */
+    uint256 public firstChainId;
+
+    /**
+     * nextChainId stores the number of the next chain that will be registered.
+     * To iterate over all chains, you can do:
+     * `for (uint256 chainId = firstChainId; chainId < nextChainId; chainId++)`
+     */
+    uint256 public nextChainId;
+
+    /**
+     * A mapping of chain ids to their respective core addresses. A core is a
+     * deployed contract to interact with the chain that has the given id.
+     * Existing chain ids are [firstChainId..nextChainId[
+     */
+    mapping(uint256 => address) public coreAddresses;
+
+    /* Constructor */
+
+    /**
+     * @param _firstChainId The first chain that gets registered will get this
+     *        id. From then on, the id will be incremented by 1 for every new
+     *        chain.
+     */
+    constructor(uint256 _firstChainId) public {
+        firstChainId = _firstChainId;
+        // As this is the constructor, the next chain will be the first one.
+        nextChainId = _firstChainId;
+    }
+
+    /* External Functions */
+
+    /**
+     * @notice Registers a new chain with Mosaic. Afterwards, validators and
+     *         users can find the chain and the respective core address in
+     *         order to interact with this.
+     *
+     * @param _coreAddress The address where the core of this chain is
+     *        deployed.
+     *
+     * @return chainId_ The id of the chain that has been registered with this
+     *         call.
+     */
+    function registerChain(
+        address _coreAddress
+    )
+        external
+        returns (uint256 chainId_)
+    {
+        // TODO: should the contract require that a core contract exists at the given address?
+        chainId_ = nextChainId;
+        nextChainId++;
+
+        coreAddresses[chainId_] = _coreAddress;
+
+        emit ChainRegistered(chainId_, _coreAddress);
+    }
+}

--- a/contracts/core/Mosaic.sol
+++ b/contracts/core/Mosaic.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.4.23;
-// Copyright 2018 OpenST Ltd.
 
+// Copyright 2018 OpenST Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/core/Mosaic.js
+++ b/test/core/Mosaic.js
@@ -19,7 +19,6 @@
 //
 // ----------------------------------------------------------------------------
 
-const assert = require('assert').strict;
 const Mosaic = artifacts.require('Mosaic');
 
 contract('Mosaic', async (accounts) => {

--- a/test/core/Mosaic.js
+++ b/test/core/Mosaic.js
@@ -1,0 +1,132 @@
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ----------------------------------------------------------------------------
+// Test: Mosaic.js
+//
+// http://www.simpletoken.org/
+//
+// ----------------------------------------------------------------------------
+
+const assert = require('assert').strict;
+const Mosaic = artifacts.require('Mosaic');
+
+contract('Mosaic', async (accounts) => {
+
+    it('should start with the chain id at the given start', async () => {
+        let expected = 14;
+        let instance = await Mosaic.new(expected);
+        let nextChainId = await instance.nextChainId.call();
+
+        assert.equal(
+            nextChainId.toNumber(),
+            expected,
+            'The next chain id should equal the id from the constructor.'
+        );
+    });
+
+    it('should assign the start id to the first chain', async () => {
+        let expectedChainId = 3;
+        let expectedCoreAddress = '0x0123456789012345678901234567890123456789';
+        let instance = await Mosaic.new(expectedChainId);
+        await instance.registerChain(expectedCoreAddress);
+        let coreAddress = await instance.coreAddresses.call(expectedChainId);
+
+        assert.equal(
+            coreAddress,
+            expectedCoreAddress,
+            'The core address of the given chain id should equal what was set.'
+        );
+    });
+
+    it('should not accept a zero address', async () => {
+        let instance = await Mosaic.new(2);
+
+        let hasThrown = false;
+        try {
+            await instance.registerChain(
+                '0x0000000000000000000000000000000000000000'
+            );
+        } catch (error) {
+            hasThrown = true;
+        }
+
+        assert.equal(
+            hasThrown,
+            true,
+            'The transaction should revert for a zero core address.'
+        );
+    });
+
+    it('should fire an event about a newly registered chain', async () => {
+        let expectedCoreAddress = '0x0123456789012345678901234567890123456789';
+        let instance = await Mosaic.new(7);
+        let transaction = await instance.registerChain(expectedCoreAddress);
+
+        eventFound = false;
+        for (let i = 0; i < transaction.logs.length; i++) {
+            let log = transaction.logs[i];
+
+            if (log.event === "ChainRegistered") {
+                assert.equal(
+                    log.args.chainId.toNumber(),
+                    7,
+                    'The logged chain\'s id should equal the first id.'
+                );
+                assert.equal(
+                    log.args.coreAddress,
+                    expectedCoreAddress,
+                    'The logged core address should equal the one from registration.'
+                );
+
+                eventFound = true;
+                break;
+            }
+        }
+
+        assert.equal(
+            eventFound,
+            true,
+            'The contract should emit a registration event.'
+        );
+    });
+
+    it('should increment each chain\'s id by exactly one', async () => {
+        let instance = await Mosaic.new(21);
+
+        let firstCoreAddress = '0x0000000000000000000000000000000000000001';
+        let secondCoreAddress = '0x0000000000000000000000000000000000000002';
+        let thirdCoreAddress = '0x0000000000000000000000000000000000000003';
+
+        await instance.registerChain(firstCoreAddress);
+        await instance.registerChain(secondCoreAddress);
+        await instance.registerChain(thirdCoreAddress);
+
+        assert.equal(
+            await instance.coreAddresses.call(21),
+            firstCoreAddress,
+            'The id of the first contract should be the initial id.'
+        );
+        assert.equal(
+            await instance.coreAddresses.call(22),
+            secondCoreAddress,
+            'The id of the second contract should be the initial id + 1.'
+        );
+        assert.equal(
+            await instance.coreAddresses.call(23),
+            thirdCoreAddress,
+            'The id of the third contract should be the initial id + 2.'
+        );
+    })
+});


### PR DESCRIPTION
The Mosaic Contract tracks auxiliary chains and the addresses of their
Core contracts on the origin chain.

There is an open TODO in the `registerChain()` method that I mould like
to get input on.

Fixes #238