### PR TITLE
Travis now builds all feature branch PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ branches:
   only:
   - master
   - develop
+  - /^feature\/.*/
 notifications:
   email:
     recipients:


### PR DESCRIPTION
If the target branch starts with the sequence `feature/`, then Travis
will build any pull request against it.

Fixes #242